### PR TITLE
godot api search and force "online lookup" options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 
 # Undo-tree save-files
 *.~undo-tree
+
+#emacs projectile
+.projectile

--- a/gdscript-customization.el
+++ b/gdscript-customization.el
@@ -130,13 +130,8 @@ so it is not slowing down Godot execution."
   :group 'gdscript)
 
 (defcustom gdscript-docs-force-online-lookup nil
-  "the string to determine if we are browsing online API to allow filtering in EWW"
+  "If true, calling commands like gdscript-docs-browse-api browses the online API reference, even if a local copy is available."
   :type 'boolean
-  :group 'gdscript)
-
-(defcustom gdscript-docs-root-match "docs.godotengine"
-  "the string to determine if we are browsing online API to allow filtering in EWW"
-  :type 'string
   :group 'gdscript)
 
 (defcustom gdscript-docs-local-path ""
@@ -148,18 +143,8 @@ directory path containing the file `index.html'."
   :type 'string
   :group 'gdscript)
 
-(defcustom gdscript-docs-online-api-url "https://docs.godotengine.org/en/stable/classes/index.html?#godot-api"
-  "Online Godot API docs URL"
-  :type 'string
-  :group 'gdscript)
-
-(defcustom gdscript-docs-online-class-lookup-url "https://docs.godotengine.org/en/stable/classes/class_%s.html#%s"
-  "Online Godot Class Lookup URL."
-  :type 'string
-  :group 'gdscript)
-
 (defcustom gdscript-docs-online-search-api-url "https://docs.godotengine.org/en/stable/search.html?q=%s&check_keywords=yes&area=default"
-  "Online Godot API search"
+  "Online Godot API search url"
   :type 'string
   :group 'gdscript)
 

--- a/gdscript-customization.el
+++ b/gdscript-customization.el
@@ -129,6 +129,16 @@ so it is not slowing down Godot execution."
   :type 'boolean
   :group 'gdscript)
 
+(defcustom gdscript-docs-force-online-lookup nil
+  "the string to determine if we are browsing online API to allow filtering in EWW"
+  :type 'boolean
+  :group 'gdscript)
+
+(defcustom gdscript-docs-root-match "docs.godotengine"
+  "the string to determine if we are browsing online API to allow filtering in EWW"
+  :type 'string
+  :group 'gdscript)
+
 (defcustom gdscript-docs-local-path ""
   "Optional path to a local build of the Godot documentation.
 If not set to an empty string, the commands `gdscript-docs-browse-api'
@@ -137,6 +147,22 @@ Must be the root directory of the website, that is to say, a
 directory path containing the file `index.html'."
   :type 'string
   :group 'gdscript)
+
+(defcustom gdscript-docs-online-api-url "https://docs.godotengine.org/en/stable/classes/index.html?#godot-api"
+  "Online Godot API docs URL"
+  :type 'string
+  :group 'gdscript)
+
+(defcustom gdscript-docs-online-class-lookup-url "https://docs.godotengine.org/en/stable/classes/class_%s.html#%s"
+  "Online Godot Class Lookup URL."
+  :type 'string
+  :group 'gdscript)
+
+(defcustom gdscript-docs-online-search-api-url "https://docs.godotengine.org/en/stable/search.html?q=%s&check_keywords=yes&area=default"
+  "Online Godot API search"
+  :type 'string
+  :group 'gdscript)
+
 
 (provide 'gdscript-customization)
 ;;; gdscript-customization.el ends here

--- a/gdscript-docs.el
+++ b/gdscript-docs.el
@@ -38,11 +38,13 @@
 (defun gdscript-docs-browse-api (&optional force-online)
   "Open the main page of Godot API. Use the universal prefix (C-u) to force browsing the online API."
   (interactive)
-  (if (and (not gdscript-docs-force-online-lookup)(or current-prefix-arg force-online) (not (string=gdscript-docs-local-path "")))
+  (if (and (or gdscript-docs-force-online-lookup current-prefix-arg force-online) (not (string= gdscript-docs-local-path "")))
+      (eww-browse-url "https://docs.godotengine.org/en/stable/classes/index.html?#godot-api")
     (let ((file (concat (file-name-as-directory gdscript-docs-local-path) "classes/index.html")))
-            (eww-open-file (file))
-    (eww-browse-url "https://docs.godotengine.org/en/stable/classes/index.html?#godot-api"
-))))
+      (if (file-exists-p file)
+          (eww-open-file file)
+        (message "\"%s\" not found" file)))
+    ))
 
 (defun gdscript-docs-browse-symbol-at-point (&optional force-online)
   "Open the API reference for the symbol at point in the browser eww.
@@ -62,14 +64,17 @@ If a page is already open, switch to its buffer. Use local docs if gdscripts-doc
       (if (string= "" symbol)
           (message "No symbol at point or open API reference buffers.")
         (if (and (not gdscript-docs-force-online-lookup)(not (or current-prefix-arg force-online)) (not (string= gdscript-docs-local-path "")))
-            (eww-open-file (concat (file-name-as-directory gdscript-docs-local-path) (file-name-as-directory "classes") "class_" symbol ".html"))
+            (let ((file (concat (file-name-as-directory gdscript-docs-local-path) (file-name-as-directory "classes") "class_" symbol ".html")))
+              (if (file-exists-p file)
+                  (eww-open-file file )
+                (message "No local API help for \"%s\"." symbol)))
           (eww-browse-url (format "https://docs.godotengine.org/en/stable/classes/class_%s.html#%s" symbol symbol) t))))))
 
 (defun gdscript-docs-online-search-api (&optional sym)
   "Search Godot docs online. Use the universal prefix (C-u) to prompt for search term."
   (interactive)
   (let ((symbol (if current-prefix-arg (read-string "API Search: ") (or sym (thing-at-point 'symbol t) ""))))
-        (browse-url (format gdscript-docs-online-search-api-url (downcase symbol)))))
+    (browse-url (format gdscript-docs-online-search-api-url (downcase symbol)))))
 
 
 (defun gdscript-docs--rename-eww-buffer ()

--- a/gdscript-docs.el
+++ b/gdscript-docs.el
@@ -35,16 +35,17 @@
 (require 'gdscript-customization)
 
 ;;;###autoload
-(defun gdscript-docs-browse-api ()
-  "Open the main page of Godot API in eww browser."
+(defun gdscript-docs-browse-api (&optional force-online)
+  "Open the main page of Godot API in eww browser. prefix (C-u) to force online"
   (interactive)
-  (if (not (string= gdscript-docs-local-path ""))
-      (eww-open-file (concat (file-name-as-directory gdscript-docs-local-path) "classes/index.html"))
-    (eww-browse-url "https://docs.godotengine.org/en/stable/classes/index.html?#godot-api")))
+  (if (and (not gdscript-docs-force-online-lookup)(or current-prefix-arg force-online) (not (string=gdscript-docs-local-path "")))
+    (let ((file (concat (file-name-as-directory gdscript-docs-local-path) "classes/index.html")))
+            (eww-open-file (file))
+    (eww-browse-url gdscript-docs-online-api-url))))
 
-(defun gdscript-docs-browse-symbol-at-point ()
+(defun gdscript-docs-browse-symbol-at-point (&optional force-online)
   "Open the API reference for the symbol at point in the browser eww.
-If a page is already open, switch to its buffer."
+If a page is already open, switch to its buffer. Use local docs if gdscripts-docs-local-path set  unless force-online or prefix (C-u)"
   (interactive)
 
   (let* ((symbol (downcase (thing-at-point 'symbol t)))
@@ -56,9 +57,15 @@ If a page is already open, switch to its buffer."
                  (string-suffix-p symbol (plist-get eww-data :url) t)
                  ))) (buffer-list))))
     (if buffer (pop-to-buffer-same-window buffer)
-      (if (not (string= gdscript-docs-local-path ""))
+      (if (and (not (or current-prefix-arg force-online)) (not (string= gdscript-docs-local-path "")))
           (eww-open-file (concat (file-name-as-directory gdscript-docs-local-path) (file-name-as-directory "classes") "class_" symbol ".html"))
-        (eww-browse-url (format "https://docs.godotengine.org/en/stable/classes/class_%s.html#%s" symbol symbol) t)))))
+        (eww-browse-url (format gdscript-docs-online-class-lookup-url symbol symbol) t)))))
+
+(defun gdscript-docs-online-search-api (&optional sym)
+  (interactive)
+  (let ((symbol (if current-prefix-arg (read-string "API Search: ") (or sym (downcase (thing-at-point 'symbol t))))))
+        (browse-url (format gdscript-docs-online-search-api-url symbol) t)))
+
 
 (defun gdscript-docs--rename-eww-buffer ()
   "Rename the eww buffer visiting the Godot documentation.
@@ -102,7 +109,7 @@ ORIG-FUN is function we wrap around.  ARGS are argument to ORIG-FUN function."
 
 (defun gdscript-docs--eww-setup ()
   "Convenience setup for pages with Godot documentation."
-  (when (string-match "docs.godotengine" (plist-get eww-data :url))
+  (when (string-match gdscript-docs-api-root-match (plist-get eww-data :url))
     (setq multi-isearch-next-buffer-function nil)
     (gdscript-docs--rename-eww-buffer)
     (gdscript-docs--filter-content-to-main-div)))

--- a/gdscript-docs.el
+++ b/gdscript-docs.el
@@ -36,12 +36,13 @@
 
 ;;;###autoload
 (defun gdscript-docs-browse-api (&optional force-online)
-  "Open the main page of Godot API in eww browser. prefix (C-u) to force online"
+  "Open the main page of Godot API. Use the universal prefix (C-u) to force browsing the online API."
   (interactive)
   (if (and (not gdscript-docs-force-online-lookup)(or current-prefix-arg force-online) (not (string=gdscript-docs-local-path "")))
     (let ((file (concat (file-name-as-directory gdscript-docs-local-path) "classes/index.html")))
             (eww-open-file (file))
-    (eww-browse-url gdscript-docs-online-api-url))))
+    (eww-browse-url "https://docs.godotengine.org/en/stable/classes/index.html?#godot-api"
+))))
 
 (defun gdscript-docs-browse-symbol-at-point (&optional force-online)
   "Open the API reference for the symbol at point in the browser eww.
@@ -59,7 +60,7 @@ If a page is already open, switch to its buffer. Use local docs if gdscripts-doc
     (if buffer (pop-to-buffer-same-window buffer)
       (if (and (not (or current-prefix-arg force-online)) (not (string= gdscript-docs-local-path "")))
           (eww-open-file (concat (file-name-as-directory gdscript-docs-local-path) (file-name-as-directory "classes") "class_" symbol ".html"))
-        (eww-browse-url (format gdscript-docs-online-class-lookup-url symbol symbol) t)))))
+        (eww-browse-url (format "https://docs.godotengine.org/en/stable/classes/class_%s.html#%s" symbol symbol) t)))))
 
 (defun gdscript-docs-online-search-api (&optional sym)
   (interactive)
@@ -109,7 +110,7 @@ ORIG-FUN is function we wrap around.  ARGS are argument to ORIG-FUN function."
 
 (defun gdscript-docs--eww-setup ()
   "Convenience setup for pages with Godot documentation."
-  (when (string-match gdscript-docs-api-root-match (plist-get eww-data :url))
+  (when (string-match "docs.godotengine" (plist-get eww-data :url))
     (setq multi-isearch-next-buffer-function nil)
     (gdscript-docs--rename-eww-buffer)
     (gdscript-docs--filter-content-to-main-div)))

--- a/gdscript-mode.el
+++ b/gdscript-mode.el
@@ -76,6 +76,7 @@
                             ;; Docs.
                             (define-key map (kbd "C-c C-b a") 'gdscript-docs-browse-api)
                             (define-key map (kbd "C-c C-b o") 'gdscript-docs-browse-symbol-at-point)
+                            (define-key map (kbd "C-c C-b s") 'gdscript-docs-online-search-api)
                             ;; Hydra
                             (define-key map (kbd "C-c r") 'gdscript-hydra-show)
                             map)


### PR DESCRIPTION
1. added function `gdscript-docs-online-search-api` (C-c C-b s)
2. added options to override local API reference and force online lookup (C-u prefix or optional function parameter) or setting `gdscript-docs-force-online-lookup` for 
> `gdscript-docs-browse-symbol-at-point`
> `gdscript-docs-browse-api`
