### PR TITLE
enable gdscript-godot-executable as defined path+exe

### DIFF
--- a/gdscript-comint.el
+++ b/gdscript-comint.el
@@ -57,9 +57,8 @@ ARGUMENTS are command line arguments for godot executable.
 When run it will kill existing process if one exists."
   (let ((buffer-name (gdscript-util--get-godot-buffer-name (member "-e" arguments)))
         (inhibit-read-only t))
-
-    (when (not (executable-find gdscript-godot-executable))
-      (error "Error: Could not find %s on PATH.  Please customize the gdscript-godot-executable variable" gdscript-godot-executable))
+    (when (not (or (f-executable-p gdscript-godot-executable) (executable-find gdscript-godot-executable)))
+      (error "Error: Could not execute '%s'.  Please customize the `gdscript-godot-executable variable'" gdscript-godot-executable))
 
     ;; start new godot
     (with-current-buffer (get-buffer-create buffer-name)

--- a/gdscript-customization.el
+++ b/gdscript-customization.el
@@ -104,9 +104,8 @@ fill parens."
   :safe 'natnump)
 
 (defcustom gdscript-godot-executable "godot"
-  "The path to the Godot executable.
-By default, it assumes that the executable is in the system's
-PATH."
+  "The godot executable which is either a full path such as '~/bin/godot2.2'
+or the name of an executable on the system PATH (usually 'godot')"
   :type 'string
   :group 'gdscript)
 


### PR DESCRIPTION
It's nice to be able to set a specific executable that may not be on the PATH or even to override it. Modified the docstring for `gdscript-godot-executable` and updated `gdscript-comint--run` to see if it's an executable, else search for it on PATH. 