### PR TITLE
Simplify gdscript-project--get-all-scripts by using call-process

### DIFF
--- a/gdscript-project.el
+++ b/gdscript-project.el
@@ -33,8 +33,6 @@
 
 (require 'gdscript-utils)
 
-(defvar gdscript-project--script-list nil)
-
 (defun gdscript-project--current-buffer-scene ()
   "Return the name of current scene.
 
@@ -64,51 +62,32 @@ If current buffer is not visiting script file return nil."
       (when (re-search-forward "^extends SceneTree\\|^extends MainLoop" nil t)
         (file-relative-name buffer-file-name (gdscript-util--find-project-configuration-file))))))
 
-(defun gdscript-project--select-script ()
+(defun gdscript-project--select-script (script-list)
   "Find all script files and let user choose one."
   (let ((hydra-open gdscript-hydra--open))
     (when hydra-open (gdscript-hydra--menu/nil))
     (unwind-protect
         (let* ((prompt (format "Buffer %s is not script file, select script to run" (buffer-name)))
-               (script-name (gdscript-util--read gdscript-project--script-list prompt)))
-          (when script-name (gdscript-godot--run-script script-name)))
+               (script-name (gdscript-util--read script-list prompt)))
+          (when script-name
+            (string-match "^\\(.*.gd\\):" script-name)
+            (gdscript-godot--run-script (match-string 1 script-name))))
       (when hydra-open (gdscript-hydra--menu/body)))))
-
-(defun gdscript-project--ag-cleanup ()
-  "Clean after ag search.
-
-Try to leave Emacs as it was before ag search was launched."
-  (remove-hook 'ag-search-finished-hook #'gdscript-project--ag-find-next-script)
-  (let* ((ag-buffer (current-buffer))
-         (ag-window (get-buffer-window ag-buffer))
-         (prev-buffer (window-prev-buffers ag-window)))
-    (if prev-buffer (kill-buffer ag-buffer)
-      (delete-window ag-window)
-      (kill-buffer ag-buffer))))
-
-(defun gdscript-project--ag-find-next-script ()
-  "Find next script file in ag buffer."
-  (let ((pos (next-single-property-change (point) 'compilation-message))
-        (comp-mes (get-text-property (point) 'compilation-message)))
-    (when comp-mes
-      (let ((file-name (caar (compilation--loc->file-struct (compilation--message->loc comp-mes)))))
-        (push file-name gdscript-project--script-list)))
-    (if pos (progn (goto-char pos)
-                   (gdscript-project--ag-find-next-script))
-      (gdscript-project--ag-cleanup)
-      (with-current-buffer (window-buffer (selected-window))
-        (gdscript-project--select-script)))))
 
 (defun gdscript-project--get-all-scripts ()
   "Find all script files and let user choose one.
 
 Since detection of script files require inspection of file contents,
 this use ag for performance."
-  (if (not (featurep 'ag))
-      (error (format "Buffer %s is no script file. To see all available scripts in current project install package 'ag'." (buffer-name)))
-    (ag-project-regexp "^extends SceneTree|^extends MainLoop")
-    (setq gdscript-project--script-list nil)
-    (add-hook 'ag-search-finished-hook #'gdscript-project--ag-find-next-script)))
+  (if (executable-find "ag")
+      (let ((default-directory (vc-git-root default-directory)))
+        (with-temp-buffer
+          (call-process "ag" nil (current-buffer) nil "--vimgrep" "-s" "^extends SceneTree|^extends MainLoop")
+          (let ((available-standalone-scripts (split-string (buffer-string) "\n" t)))
+            (if (null available-standalone-scripts)
+                (message "No standalone script found. Look at https://docs.godotengine.org/en/stable/getting_started/editor/command_line_tutorial.html#running-a-script for details.")
+              (gdscript-project--select-script available-standalone-scripts)))))
+    (error (format "Buffer %s is no script file. To see all available scripts install 'ag' executable." (buffer-name)))))
 
 (provide 'gdscript-project)
 


### PR DESCRIPTION
rather than ag-project-regexp from ag.el.