### PR TITLE
Replace old repository path

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,12 +148,12 @@ Add the call to use-package to your Emacs configuration:
     :straight (gdscript-mode
                :type git
                :host github
-               :repo "GDQuest/emacs-gdscript-mode"))
+               :repo "godotengine/emacs-gdscript-mode"))
 ```
 
 ### Installing manually
 
-1. Clone the repository or download a [stable release](https://github.com/GDQuest/emacs-gdscript-mode/releases) to your computer.
+1. Clone the repository or download a [stable release](https://github.com/godotengine/emacs-gdscript-mode/releases) to your computer.
 1. In your init.el file, add a call to load and require the package.
 
 ```elisp

--- a/gdscript-comint-gdformat.el
+++ b/gdscript-comint-gdformat.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2020 GDQuest and contributors
 ;;
 ;; Author: Josef Vlach <vlach.josef@gmail.com>
-;; URL: https://github.com/GDQuest/emacs-gdscript-mode/
+;; URL: https://github.com/godotengine/emacs-gdscript-mode/
 ;; Version: 1.0.0
 ;; Package-Requires: ((emacs "26.3"))
 ;; Maintainer: nathan@gdquest.com

--- a/gdscript-comint.el
+++ b/gdscript-comint.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2020 GDQuest and contributors
 ;;
 ;; Author: Josef Vlach <vlach.josef@gmail.com>
-;; URL: https://github.com/GDQuest/emacs-gdscript-mode/
+;; URL: https://github.com/godotengine/emacs-gdscript-mode/
 ;; Version: 1.0.0
 ;; Package-Requires: ((emacs "26.3"))
 ;; Maintainer: nathan@gdquest.com

--- a/gdscript-completion.el
+++ b/gdscript-completion.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2020 GDQuest
 
 ;; Author: Nathan Lovato <nathan@gdquest.com>, Fabián E. Gallina <fgallina@gnu.org>
-;; URL: https://github.com/GDQuest/emacs-gdscript-mode/
+;; URL: https://github.com/godotengine/emacs-gdscript-mode/
 ;; Version: 0.1.0
 ;; Package-Requires: ((emacs "26.3"))
 ;; Maintainer: nathan@gdquest.com

--- a/gdscript-customization.el
+++ b/gdscript-customization.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2020 GDQuest
 
 ;; Author: Nathan Lovato <nathan@gdquest.com>
-;; URL: https://github.com/GDQuest/emacs-gdscript-mode/
+;; URL: https://github.com/godotengine/emacs-gdscript-mode/
 ;; Version: 0.1.0
 ;; Package-Requires: ((emacs "26.3"))
 ;; Maintainer: nathan@gdquest.com

--- a/gdscript-debug.el
+++ b/gdscript-debug.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2020 GDQuest
 
 ;; Author: Josef Vlach <vlach.josef@gmail.com>
-;; URL: https://github.com/GDQuest/emacs-gdscript-mode/
+;; URL: https://github.com/godotengine/emacs-gdscript-mode/
 ;; Version: 0.0.1
 ;; Package-Requires: ((emacs "26.3"))
 ;; Maintainer: vlach.josef@gmail.com

--- a/gdscript-docs.el
+++ b/gdscript-docs.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2020 GDQuest and contributors
 ;;
 ;; Author: Josef Vlach <vlach.josef@gmail.com>
-;; URL: https://github.com/GDQuest/emacs-gdscript-mode/
+;; URL: https://github.com/godotengine/emacs-gdscript-mode/
 ;; Version: 1.0.0
 ;; Package-Requires: ((emacs "26.3"))
 ;; Maintainer: nathan@gdquest.com

--- a/gdscript-fill-paragraph.el
+++ b/gdscript-fill-paragraph.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2020 GDQuest
 
 ;; Author: Nathan Lovato <nathan@gdquest.com>
-;; URL: https://github.com/GDQuest/emacs-gdscript-mode/
+;; URL: https://github.com/godotengine/emacs-gdscript-mode/
 ;; Version: 0.1.0
 ;; Package-Requires: ((emacs "26.3"))
 ;; Maintainer: nathan@gdquest.com

--- a/gdscript-format.el
+++ b/gdscript-format.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2020 GDQuest, Pawel Lampe
 
 ;; Author: Pawel Lampe <pawel.lampe@gmail.com>, Nathan Lovato <nathan@gdquest.com>
-;; URL: https://github.com/GDQuest/emacs-gdscript-mode/
+;; URL: https://github.com/godotengine/emacs-gdscript-mode/
 ;; Version: 1.0.0
 ;; Package-Requires: ((emacs "26.3"))
 ;; Maintainer: nathan@gdquest.com

--- a/gdscript-godot.el
+++ b/gdscript-godot.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2020 GDQuest and contributors
 ;;
 ;; Author: Franco Eusébio Garcia <francoegarcia@outlook.com>, Nathan Lovato <nathan@gdquest.com>
-;; URL: https://github.com/GDQuest/emacs-gdscript-mode/
+;; URL: https://github.com/godotengine/emacs-gdscript-mode/
 ;; Version: 1.0.0
 ;; Package-Requires: ((emacs "26.3"))
 ;; Maintainer: nathan@gdquest.com

--- a/gdscript-history.el
+++ b/gdscript-history.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2020 GDQuest and contributors
 ;;
 ;; Author: Josef Vlach <vlach.josef@gmail.com>
-;; URL: https://github.com/GDQuest/emacs-gdscript-mode/
+;; URL: https://github.com/godotengine/emacs-gdscript-mode/
 ;; Version: 1.0.0
 ;; Package-Requires: ((emacs "26.3"))
 ;; Maintainer: nathan@gdquest.com

--- a/gdscript-hydra.el
+++ b/gdscript-hydra.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2020 GDQuest and contributors
 ;;
 ;; Author: Josef Vlach <vlach.josef@gmail.com>
-;; URL: https://github.com/GDQuest/emacs-gdscript-mode/
+;; URL: https://github.com/godotengine/emacs-gdscript-mode/
 ;; Version: 1.0.0
 ;; Package-Requires: ((emacs "26.3"))
 ;; Maintainer: nathan@gdquest.com

--- a/gdscript-imenu.el
+++ b/gdscript-imenu.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2020 GDQuest
 
 ;; Author: Nathan Lovato <nathan@gdquest.com>, Fabián E. Gallina <fgallina@gnu.org>
-;; URL: https://github.com/GDQuest/emacs-gdscript-mode/
+;; URL: https://github.com/godotengine/emacs-gdscript-mode/
 ;; Version: 1.0.0
 ;; Package-Requires: ((emacs "26.3"))
 ;; Maintainer: nathan@gdquest.com

--- a/gdscript-indent-and-nav.el
+++ b/gdscript-indent-and-nav.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2020 GDQuest
 
 ;; Author: Nathan Lovato <nathan@gdquest.com>, Fabián E. Gallina <fgallina@gnu.org>
-;; URL: https://github.com/GDQuest/emacs-gdscript-mode/
+;; URL: https://github.com/godotengine/emacs-gdscript-mode/
 ;; Version: 1.0.0
 ;; Package-Requires: ((emacs "26.3"))
 ;; Maintainer: nathan@gdquest.com

--- a/gdscript-keywords.el
+++ b/gdscript-keywords.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2020 GDQuest
 
 ;; Author: Nathan Lovato <nathan@gdquest.com>
-;; URL: https://github.com/GDQuest/emacs-gdscript-mode/
+;; URL: https://github.com/godotengine/emacs-gdscript-mode/
 ;; Version: 0.1.0
 ;; Package-Requires: ((emacs "26.3"))
 ;; Maintainer: nathan@gdquest.com

--- a/gdscript-mode.el
+++ b/gdscript-mode.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2020 GDQuest
 
 ;; Author: Nathan Lovato <nathan@gdquest.com>, Fabián E. Gallina <fgallina@gnu.org>
-;; URL: https://github.com/GDQuest/emacs-gdscript-mode/
+;; URL: https://github.com/godotengine/emacs-gdscript-mode/
 ;; Version: 0.1.0
 ;; Package-Requires: ((emacs "26.3"))
 ;; Maintainer: nathan@gdquest.com

--- a/gdscript-project.el
+++ b/gdscript-project.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2020 GDQuest and contributors
 ;;
 ;; Author: Josef Vlach <vlach.josef@gmail.com>
-;; URL: https://github.com/GDQuest/emacs-gdscript-mode/
+;; URL: https://github.com/godotengine/emacs-gdscript-mode/
 ;; Version: 1.0.0
 ;; Package-Requires: ((emacs "26.3"))
 ;; Maintainer: nathan@gdquest.com

--- a/gdscript-rx.el
+++ b/gdscript-rx.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2020 GDQuest
 
 ;; Author: Nathan Lovato <nathan@gdquest.com>, Fabián E. Gallina <fgallina@gnu.org>
-;; URL: https://github.com/GDQuest/emacs-gdscript-mode/
+;; URL: https://github.com/godotengine/emacs-gdscript-mode/
 ;; Version: 1.0.0
 ;; Package-Requires: ((emacs "26.3"))
 ;; Maintainer: nathan@gdquest.com

--- a/gdscript-syntax.el
+++ b/gdscript-syntax.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2020 GDQuest
 
 ;; Author: Nathan Lovato <nathan@gdquest.com>, Fabián E. Gallina <fgallina@gnu.org>
-;; URL: https://github.com/GDQuest/emacs-gdscript-mode/
+;; URL: https://github.com/godotengine/emacs-gdscript-mode/
 ;; Version: 1.0.0
 ;; Package-Requires: ((emacs "26.3"))
 ;; Maintainer: nathan@gdquest.com

--- a/gdscript-tests.el
+++ b/gdscript-tests.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2020 GDQuest and contributors
 ;;
 ;; Author: Josef Vlach <vlach.josef@gmail.com>
-;; URL: https://github.com/GDQuest/emacs-gdscript-mode/
+;; URL: https://github.com/godotengine/emacs-gdscript-mode/
 ;; Version: 1.0.0
 ;; Package-Requires: ((emacs "26.3"))
 ;; Maintainer: nathan@gdquest.com

--- a/gdscript-utils.el
+++ b/gdscript-utils.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2020 GDQuest
 
 ;; Author: Nathan Lovato <nathan@gdquest.com>, Fabián E. Gallina <fgallina@gnu.org>
-;; URL: https://github.com/GDQuest/emacs-gdscript-mode/
+;; URL: https://github.com/godotengine/emacs-gdscript-mode/
 ;; Version: 0.1.0
 ;; Package-Requires: ((emacs "26.3"))
 ;; Maintainer: nathan@gdquest.com


### PR DESCRIPTION
The repository was moved from GDQuest to godotengine between 1.2 and 1.3. While [old GitHub links are redirected](https://docs.github.com/en/github/administering-a-repository/transferring-a-repository), it's probably for the better if the links in the code and its documentation point to the current repository.