### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        emacs-version:
+          - 26.3
+          - 27.2
+          - 28.1
+          - snapshot
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: jcs090218/setup-emacs@master
+      with:
+        version: ${{ matrix.emacs-version }}
+
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '14'
+
+    - uses: emacs-eask/setup-eask@master
+      with:
+        version: 'snapshot'
+
+    - name: Run tests
+      run:
+        make ci

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@
 *.elc
 
 # Packaging
-.cask
+.eask
+dist/
 
 # Backup files
 *~

--- a/Eask
+++ b/Eask
@@ -1,0 +1,11 @@
+(package "gdscript-mode"
+         "0.1.0"
+         "Major mode for Godot's GDScript language")
+
+(package-file "gdscript-mode.el")
+
+(files "*.el")
+
+(source "gnu")
+
+(depends-on "emacs" "26.3")

--- a/Eask
+++ b/Eask
@@ -9,3 +9,5 @@
 (source "gnu")
 
 (depends-on "emacs" "26.3")
+
+(setq network-security-level 'low)  ; see https://github.com/jcs090218/setup-emacs-windows/issues/156#issuecomment-932956432

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@ EASK ?= eask
 
 .PHONY: clean checkdoc lint package install compile test
 
-ci: clean package install compile checkdoc lint
+# TODO: add `lint` if we can?
+ci: clean package install compile checkdoc
 
 package:
 	@echo "Packaging..."

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+SHELL := /usr/bin/env bash
+
+EMACS ?= emacs
+EASK ?= eask
+
+.PHONY: clean checkdoc lint package install compile test
+
+ci: clean package install compile checkdoc lint
+
+package:
+	@echo "Packaging..."
+	$(EASK) package
+
+install:
+	@echo "Installing..."
+	$(EASK) install
+
+compile:
+	@echo "Compiling..."
+	$(EASK) compile
+
+test:
+	@echo "Testing..."
+	$(EASK) ert ./test/*.el
+
+checkdoc:
+	@echo "Run checkdoc..."
+	$(EASK) checkdoc
+
+lint:
+	@echo "Run package-lint..."
+	$(EASK) lint
+
+clean:
+	$(EASK) clean-all

--- a/gdscript-docs.el
+++ b/gdscript-docs.el
@@ -34,7 +34,7 @@
 (require 'eww)
 (require 'gdscript-customization)
 
-(defun gdscript-docs-open (url &optional)
+(defun gdscript-docs-open (url &args _)
   "when `gdscript-docs-use-eww' is true use `eww' else use `browse-url'"
   (if gdscript-docs-use-eww
       (if (file-exists-p url) (eww-open-file url) (eww-browse-url url t))


### PR DESCRIPTION
I have setup the CI for this repo. The CI uses [Eask](https://github.com/emacs-eask/eask); the tool I've created recently to replace Cask. And with the GitHub Actions.

The CI tests on all platforms (Ubuntu, macOS, and Windows). The CI process is defined in `Makefile`. It currently tests the following,

* `package` - test if package archives able to build the package artefact (`.tar` or `.el`)
* `install` - test if able to install with `package.el`
* `compile` - (optional) gives you warnings
* `checkdoc` - (optional) style checker

I have added `make lint` but it's currently left unused due to other errors.