### PR TITLE
Fix docs open wrong number of args err

### DIFF
--- a/gdscript-docs.el
+++ b/gdscript-docs.el
@@ -34,7 +34,7 @@
 (require 'eww)
 (require 'gdscript-customization)
 
-(defun gdscript-docs-open (url &args _)
+(defun gdscript-docs-open (url &rest _)
   "when `gdscript-docs-use-eww' is true use `eww' else use `browse-url'"
   (if gdscript-docs-use-eww
       (if (file-exists-p url) (eww-open-file url) (eww-browse-url url t))


### PR DESCRIPTION
https://github.com/godotengine/emacs-gdscript-mode/issues/115

