### PR TITLE
tests: Setup node is no longer required

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
         emacs-version:
           - 26.3
           - 27.2
-          - 28.1
+          - 28.2
           - snapshot
 
     steps:
@@ -29,10 +29,6 @@ jobs:
     - uses: jcs090218/setup-emacs@master
       with:
         version: ${{ matrix.emacs-version }}
-
-    - uses: actions/setup-node@v2
-      with:
-        node-version: '14'
 
     - uses: emacs-eask/setup-eask@master
       with:

--- a/Eask
+++ b/Eask
@@ -2,8 +2,10 @@
          "0.1.0"
          "Major mode for Godot's GDScript language")
 
-(package-file "gdscript-mode.el")
+(website-url "https://github.com/godotengine/emacs-gdscript-mode/")
+(keywords "languages")
 
+(package-file "gdscript-mode.el")
 (files "*.el")
 
 (source "gnu")


### PR DESCRIPTION
This is no longer needed for [setup-eask](https://github.com/emacs-eask/setup-eask).