### PR TITLE
Added integration with eglot

### DIFF
--- a/gdscript-eglot.el
+++ b/gdscript-eglot.el
@@ -1,0 +1,75 @@
+;;; gdscript-eglot.el --- Integration with eglot -*- lexical-binding: t; -*-
+;;
+;; Copyright (C) 2023 GDQuest and contributors
+;;
+;; Author: Ruijie Yu <ruijie@netyu.xyz>
+;; URL: https://github.com/godotengine/emacs-gdscript-mode/
+;; Version: 1.0.0
+;; Package-Requires: ((emacs "26.3"))
+;; Maintainer: nathan@gdquest.com
+;; Created: June 2020
+;; Keywords: languages
+;;
+;; This file is not part of GNU Emacs.
+;;
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;;; Commentary:
+;;
+;; Handles the configuraiton of eglot.
+;; This supports `gdscript-mode' using `eglot'.
+;;
+;;; Code:
+
+;;;###autoload
+(defgroup gdscript-eglot nil
+  "Configurations in gdscript related to `eglot'."
+  :group 'gdscript)
+
+;;;###autoload
+(defcustom gdscript-eglot-version 4
+  "The version of godot in use."
+  :type 'integer)
+
+;;;###autoload
+(defun gdscript-eglot-contact (_interactive)
+  "Attempt to help `eglot' contact the running gdscript LSP.
+Returns a list (HOST PORT) if successful, nil otherwise.  See the
+last definition of CONTACT in `eglot-server-programs' for
+definitions of HOST, PORT, and INTERACTIVE.
+
+For more context, see
+https://lists.gnu.org/archive/html/bug-gnu-emacs/2023-04/msg01070.html."
+  (save-excursion
+    (let* ((cfg-dir (or (getenv "XDG_CONFIG_HOME") "~/.config"))
+           (cfg-buffer
+            (find-file-noselect
+             (expand-file-name
+              (format "godot/editor_settings-%d.tres"
+                      gdscript-eglot-version)
+              cfg-dir)))
+           (port
+            (with-current-buffer cfg-buffer
+              (and
+               (re-search-forward
+                (rx "network/language_server/remote_port"
+                    (* space) ?= (* space)
+                    (group (+ digit)))
+                nil t)
+               (string-to-number (match-string 1))))))
+      ;; then return the host-port list when found
+      (and port (list "localhost" port)))))
+
+(provide 'gdscript-eglot)
+;;; gdscript-eglot.el ends here.

--- a/gdscript-mode.el
+++ b/gdscript-mode.el
@@ -26,7 +26,7 @@
 ;;; Commentary:
 
 ;; Adds support for the GDScript programming language from the Godot game
-;; engine. This is a domain-specific language dedicated to game programming.
+;; engine.  This is a domain-specific language dedicated to game programming.
 
 ;;; Code:
 
@@ -42,6 +42,7 @@
 (require 'gdscript-godot)
 (require 'gdscript-hydra)
 (require 'gdscript-debug)
+(require 'gdscript-eglot)
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.gd\\'" . gdscript-mode))
@@ -49,6 +50,11 @@
 (add-to-list 'auto-mode-alist '("\\.tscn\\'" . conf-toml-mode))
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.tres\\'" . conf-toml-mode))
+;;;###autoload
+(with-eval-after-load 'eglot
+  (defvar eglot-server-programs)
+  (push (cons 'gdscript-mode #'gdscript-eglot-contact)
+        eglot-server-programs))
 
 (defvar gdscript-mode-map (let ((map (make-sparse-keymap)))
                             ;; Movement


### PR DESCRIPTION
Fixes #121.

* gdscript-eglot.el gdscript-eglot-version: added customizable option for the godot version in use.
(gdscript-eglot-contact): added function to allow `eglot` to find the godot LSP port.