### PR TITLE
Follow indent cleaning

### DIFF
--- a/gdscript-indent-and-nav.el
+++ b/gdscript-indent-and-nav.el
@@ -347,11 +347,7 @@ to the maximum available level.  When indentation is the minimum
 possible and PREVIOUS is non-nil, cycle back to the maximum
 level."
   (let ((follow-indentation-p
-         ;; Check if point is within indentation.
-         (and (<= (line-beginning-position) (point))
-              (>= (+ (line-beginning-position)
-                     (current-indentation))
-                  (point)))))
+         (<= (current-column) (current-indentation))))
     (save-excursion
       (indent-line-to
        (gdscript-indent-calculate-indentation previous))


### PR DESCRIPTION
`(line-beginning-position)` and `(point)` work with a "character number format" (tab = 1 character)
but `(current-indentation)` give the column number of the indentation (tab = 4 columns)

This cause the cursor to go back to indentation when cursor is on one of 3 characters after the current indentation 

Using `(current-indentation)` and `(current-indentation)` fix and use the same convention of "column numbering" (and is cleaner)

Get rid of `(<= (line-beginning-position) (point))` which I really don't get the purpose. 
Remove the comment since it becomes self explanatory