### PR TITLE
Fix file path completion when projectile is used

### DIFF
--- a/gdscript-completion.el
+++ b/gdscript-completion.el
@@ -63,23 +63,22 @@ first."
   (let ((has-projectile (featurep 'projectile)))
     (when has-projectile
       (projectile-maybe-invalidate-cache arg))
-    (let* ((project-root
-            (if has-projectile
-                (projectile-ensure-project (projectile-project-root))
-              (gdscript-util--find-project-configuration-file)))
-           (file
-            (if has-projectile
-                (projectile-completing-read
-                 "Find file: "
-                 (projectile-project-files project-root))
-              (read-file-name
-               "Find file: "
-               project-root))))
-      (when file
-        (insert
-         (concat "\"res://"
-                 (gdscript-util--get-godot-project-file-path-relative file)
-                 "." (file-name-extension file) "\""))))))
+    (when-let* ((project-root
+                 (if has-projectile
+                     (projectile-ensure-project (projectile-project-root))
+                   (gdscript-util--find-project-configuration-file)))
+                (file
+                 (if has-projectile
+                     (projectile-completing-read
+                      "Find file: "
+                      (projectile-project-files project-root))
+                   (read-file-name
+                    "Find file: "
+                    project-root))))
+      (insert
+       (concat "\"res://"
+               (gdscript-util--get-godot-project-file-path-relative file)
+               "." (file-name-extension file) "\"")))))
 
 
 (provide 'gdscript-completion)

--- a/gdscript-completion.el
+++ b/gdscript-completion.el
@@ -74,11 +74,13 @@ first."
                       (projectile-project-files project-root))
                    (read-file-name
                     "Find file: "
-                    project-root))))
-      (insert
-       (concat "\"res://"
-               (gdscript-util--get-godot-project-file-path-relative file)
-               "." (file-name-extension file) "\"")))))
+                    project-root)))
+                (resource-path
+                 (if has-projectile
+                     file
+                   (concat (gdscript-util--get-godot-project-file-path-relative file)
+                           "." (file-name-extension file)))))
+      (insert (concat "\"res://" resource-path "\"")))))
 
 
 (provide 'gdscript-completion)


### PR DESCRIPTION
When projectile is being used, `projectile-project-files` already returns file paths relative to the project root directory, so `gdscript-util--get-godot-project-file-path-relative` should not be used.