### PR TITLE
fix: remove extra /godot from osx/windows config path

### DIFF
--- a/gdscript-eglot.el
+++ b/gdscript-eglot.el
@@ -56,11 +56,11 @@ https://lists.gnu.org/archive/html/bug-gnu-emacs/2023-04/msg01070.html."
                         (pcase system-type
                           ('darwin "~/Library/Application Support/Godot/")
                           ('windows-nt "%APPDATA%\\Godot\\")
-                          ('gnu/linux "~/.config/"))))
+                          ('gnu/linux "~/.config/godot/"))))
            (cfg-buffer
             (find-file-noselect
              (expand-file-name
-              (format "godot/editor_settings-%d.tres"
+              (format "editor_settings-%d.tres"
                       gdscript-eglot-version)
               cfg-dir)))
            (port


### PR DESCRIPTION
https://github.com/godotengine/emacs-gdscript-mode/pull/138 was a good step, but the darwin and windows paths were not quite right when combined with the editor-settings path below - it was digging into an extra '/godot' directory and never finding the settings. This lifts that 'godot/' dir to only the linux system type.

The docs for the paths are here:
https://docs.godotengine.org/en/stable/tutorials/io/data_paths.html#editor-data-paths

Eglot now starts automagically for me on osx! yay!