### PR TITLE
eglot: fix config file path on macOS

### DIFF
--- a/gdscript-eglot.el
+++ b/gdscript-eglot.el
@@ -56,11 +56,11 @@ https://lists.gnu.org/archive/html/bug-gnu-emacs/2023-04/msg01070.html."
                         (pcase system-type
                           ('darwin "~/Library/Application Support/Godot/")
                           ('windows-nt "%APPDATA%\\Godot\\")
-                          ('gnu/linux "~/.config/"))))
+                          ('gnu/linux "~/.config/godot"))))
            (cfg-buffer
             (find-file-noselect
              (expand-file-name
-              (format "godot/editor_settings-%d.tres"
+              (format "editor_settings-%d.tres"
                       gdscript-eglot-version)
               cfg-dir)))
            (port


### PR DESCRIPTION
The `Application Support/Godot` directory does not have a `godot` subdirectory on my machine (running Godot 4). I'm not sure if the Windows version does, and I'm also not sure about Godot 3.