### PR TITLE
Change gdscript-eglot-version type to be string instead of integer

### DIFF
--- a/gdscript-eglot.el
+++ b/gdscript-eglot.el
@@ -38,7 +38,7 @@
   :group 'gdscript)
 
 ;;;###autoload
-(defcustom gdscript-eglot-version "4"
+(defcustom gdscript-eglot-version "4.3"
   "The version of godot in use."
   :type 'string)
 

--- a/gdscript-eglot.el
+++ b/gdscript-eglot.el
@@ -38,9 +38,9 @@
   :group 'gdscript)
 
 ;;;###autoload
-(defcustom gdscript-eglot-version 4
+(defcustom gdscript-eglot-version "4"
   "The version of godot in use."
-  :type 'integer)
+  :type 'string)
 
 ;;;###autoload
 (defun gdscript-eglot-contact (_interactive)
@@ -60,7 +60,7 @@ https://lists.gnu.org/archive/html/bug-gnu-emacs/2023-04/msg01070.html."
            (cfg-buffer
             (find-file-noselect
              (expand-file-name
-              (format "godot/editor_settings-%d.tres"
+              (format "godot/editor_settings-%s.tres"
                       gdscript-eglot-version)
               cfg-dir)))
            (port


### PR DESCRIPTION
Customizable variable `gdscript-eglot-version` is used to locate editor settings file and extract LSP port from it when connecting via Eglot. Currently, this variable is of type integer.

In godotengine/godot#90875, naming logic for the editor settings file was changed, and if you have, for example, Godot 4.3 installed, the corresponding editor settings file will be named `editor_settings-4.3.tres`. Because `gdscript-eglot-version` has an integer type and is formatted as such, it is impossible to specify the correct version of the Godot installation in that case.

I changed the type of `gdscript-eglot-version` to a string to be able to specify any possible version format. Also, I've bumped the value of `gdscript-eglot-version` to the last stable version of Godot. As stated in #154, we can improve LSP port determination further by avoiding hard-coding this value, but this is good enough for now.