### PR TITLE
Refactor eglot-server-programs

### DIFF
--- a/gdscript-mode.el
+++ b/gdscript-mode.el
@@ -56,7 +56,8 @@
 ;;;###autoload
 (with-eval-after-load 'eglot
   (add-to-list 'eglot-server-programs
-               '(gdscript-mode . gdscript-eglot-contact)))
+               '((gdscript-mode gdscript-ts-mode)
+                 . gdscript-eglot-contact)))
 
 (defvar gdscript-mode-map (let ((map (make-sparse-keymap)))
                             ;; Movement

--- a/gdscript-mode.el
+++ b/gdscript-mode.el
@@ -55,11 +55,8 @@
 (add-to-list 'auto-mode-alist '("\\.tres\\'" . conf-toml-mode))
 ;;;###autoload
 (with-eval-after-load 'eglot
-  (defvar eglot-server-programs)
-  (unless (equal (alist-get 'gdscript-mode eglot-server-programs)
-                 #'gdscript-eglot-contact)
-    (push (cons 'gdscript-mode #'gdscript-eglot-contact)
-          eglot-server-programs)))
+  (add-to-list 'eglot-server-programs
+               '(gdscript-mode . gdscript-eglot-contact)))
 
 (defvar gdscript-mode-map (let ((map (make-sparse-keymap)))
                             ;; Movement


### PR DESCRIPTION
Using `add-to-list` is idiomatic when we want to add some value to the list if it isn’t there. Also, we don't need to `(defvar eglot-server-programs)` and `gdscript-ts-mode` should be there as well.