### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ To support Gdscript, we must install [gdscript-grammar](https://github.com/Prest
 git clone https://github.com/PrestonKnopp/tree-sitter-gdscript.git
 cd tree-sitter-gdscript/src
 cc -std=c99 -c parser.c
-cc -c scanner.cc
+cc -c scanner.c -I./
 cc -shared parser.o scanner.o -o libtree-sitter-gdscript.so
 ```
 


### PR DESCRIPTION
Fix extra c in `scanner.c`
It also seems I need to add `-I./` to avoid:
```
scanner.c:5:10: fatal error: tree_sitter/parser.h: No such file or directory
    5 | #include <tree_sitter/parser.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```