### PR TITLE
Better gdscript-ts-mode highlighting

### DIFF
--- a/gdscript-ts-mode.el
+++ b/gdscript-ts-mode.el
@@ -78,11 +78,15 @@ It must be a function with two arguments: TYPE and NAME.")
                                         "puppet" "remote" "remotesync" "return" "setget" "signal"
                                         "var" "while"))
 
-;;; Setting
+;;; Types
 
-(defvar gdscript-ts--type-regex "\\`[A-Z][a-zA-Z0-9_]*[a-z][a-zA-Z0-9_]*\\'")
+(defvar gdscript-ts--type-regex "\\`\\(int\\|bool\\|float\\|void\\|[A-Z][a-zA-Z0-9_]*[a-z][a-zA-Z0-9_]*\\)\\'")
+
+;;; Constants
 
 (defvar gdscript-ts--constant-regex "\\`[A-Z_][A-Z0-9_]+\\'")
+
+;;; Setting
 
 (defvar gdscript-ts--feature-list
   '(( comment definition)
@@ -117,10 +121,7 @@ It must be a function with two arguments: TYPE and NAME.")
 
    :language 'gdscript
    :feature 'type
-   `(((identifier) @font-lock-type-face
-      (:match ,(rx (| "int" "bool" "float" "void")) @font-lock-type-face))
-     ((identifier) @font-lock-type-face
-      (:match ,gdscript-ts--type-regex @font-lock-type-face))
+   `(((identifier) @font-lock-type-face (:match ,gdscript-ts--type-regex @font-lock-type-face))
      (enum_definition name: (_) @font-lock-type-face)
      (get_node) @font-lock-type-face)
 
@@ -134,9 +135,9 @@ It must be a function with two arguments: TYPE and NAME.")
    :feature 'keyword
    `(([,@gdscript-ts--treesit-keywords] @font-lock-keyword-face)
      (call (identifier) @font-lock-keyword-face
-           (:match ,(rx (| "yield")) @font-lock-keyword-face))
-     (attribute (identifier) @font-lock-keyword-face
-                (:match ,(rx (| "self")) @font-lock-keyword-face))
+           (:match "yield" @font-lock-keyword-face))
+     ((identifier) @font-lock-keyword-face
+                (:match "self" @font-lock-keyword-face))
      (await_expression "await" @font-lock-keyword-face)
      (static_keyword) @font-lock-keyword-face)
 

--- a/gdscript-ts-mode.el
+++ b/gdscript-ts-mode.el
@@ -71,16 +71,22 @@ It must be a function with two arguments: TYPE and NAME.")
 
 ;;; Keywords
 
-(defvar gdscript-ts--treesit-keywords '("and" "as" "break" "class" "class_name"
-                                        "const" "continue" "elif" "else" "enum"
-                                        "export" "extends" "for" "func" "if" "in" "is"
-                                        "master" "match" "not" "onready" "or" "pass"
-                                        "puppet" "remote" "remotesync" "return" "setget" "signal"
-                                        "var" "while"))
+(defvar gdscript-ts--keyword-regex
+  (rx bot (| "func" "var" "const" "set" "get" "setget" "signal" "extends"
+             "match" "if" "elif" "else" "while" "break" "continue" "pass"
+             "return" "when" "yield" "await"
+             "class" "class_name" "abstract" "is" "onready" "tool" "static"
+             "export" "as" "void" "enum" "assert" "breakpoint"
+             "sync" "remote" "master" "puppet"
+             "remotesync" "mastersync" "puppetsync"
+             "trait" "namespace" "super"
+             "and" "or" "not"
+             "await" "yield" "self") eot))
 
 ;;; Types
 
-(defvar gdscript-ts--type-regex "\\`\\(int\\|bool\\|float\\|void\\|[A-Z][a-zA-Z0-9_]*[a-z][a-zA-Z0-9_]*\\)\\'")
+(defvar gdscript-ts--type-regex
+  "\\`\\(int\\|bool\\|float\\|void\\|[A-Z][a-zA-Z0-9_]*[a-z][a-zA-Z0-9_]*\\)\\'")
 
 ;;; Constants
 
@@ -121,7 +127,8 @@ It must be a function with two arguments: TYPE and NAME.")
 
    :language 'gdscript
    :feature 'type
-   `(((identifier) @font-lock-type-face (:match ,gdscript-ts--type-regex @font-lock-type-face))
+   `(((identifier) @font-lock-type-face
+      (:match ,gdscript-ts--type-regex @font-lock-type-face))
      (enum_definition name: (_) @font-lock-type-face)
      (class_name_statement (name) @font-lock-type-face)
      (get_node) @font-lock-type-face)
@@ -133,14 +140,13 @@ It must be a function with two arguments: TYPE and NAME.")
      (parameters (identifier) @font-lock-variable-name-face))
 
    :language 'gdscript
+   :feature 'annotation
+   '((annotation "@" @font-lock-preprocessor-face
+                 (identifier) @font-lock-preprocessor-face))
+
+   :language 'gdscript
    :feature 'keyword
-   `(([,@gdscript-ts--treesit-keywords] @font-lock-keyword-face)
-     (call (identifier) @font-lock-keyword-face
-           (:match "yield" @font-lock-keyword-face))
-     ((identifier) @font-lock-keyword-face
-                (:match "self" @font-lock-keyword-face))
-     (await_expression "await" @font-lock-keyword-face)
-     (static_keyword) @font-lock-keyword-face)
+   `((_ _ @font-lock-keyword-face (:match ,gdscript-ts--keyword-regex @font-lock-keyword-face)))
 
    :language 'gdscript
    :feature 'string
@@ -163,15 +169,11 @@ It must be a function with two arguments: TYPE and NAME.")
    :language 'gdscript
    `(["+" "+="   "-" "-=" "*" "*=" "/" "/=" "^"  "^="  ">"  ">="
       "<" "<="   "|" "|=" "%" "%=" "&" "&=" ">>" ">>=" "<<" "<<="
-      "||" "&&" "==" "!=" "->" "~" "="] @font-lock-operator-face)
+      "||" "&&" "==" "!=" "->" "~" "=" ":="] @font-lock-operator-face)
 
    :language 'gdscript
    :feature 'escape-sequence
-   '((escape_sequence) @font-lock-escape-face)
-
-   :language 'gdscript
-   :feature 'annotation
-   '((annotation "@" @font-lock-preprocessor-face (identifier) @font-lock-preprocessor-face))))
+   '((escape_sequence) @font-lock-escape-face)))
 
 
 ;;; Funtion

--- a/gdscript-ts-mode.el
+++ b/gdscript-ts-mode.el
@@ -176,9 +176,11 @@ It must be a function with two arguments: TYPE and NAME.")
    :language 'gdscript
    `(["+" "+="   "-" "-=" "*" "*=" "/" "/=" "^"  "^="  ">"  ">="
       "<" "<="   "|" "|=" "%" "%=" "&" "&=" ">>" ">>=" "<<" "<<="
-      "||" "&&" "==" "!=" "->" "~" "=" ":="] @font-lock-operator-face)
+      "||" "&&" "==" "!=" "->" "~" "=" ":="]
+     @font-lock-operator-face)
 
    :language 'gdscript
+   :override t
    :feature 'escape-sequence
    '((escape_sequence) @font-lock-escape-face)))
 

--- a/gdscript-ts-mode.el
+++ b/gdscript-ts-mode.el
@@ -137,12 +137,12 @@ It must be a function with two arguments: TYPE and NAME.")
      ((identifier) @font-lock-type-face
       (:match ,gdscript-ts--type-regex @font-lock-type-face))
      (enum_definition name: (_) @font-lock-type-face)
-     (class_name_statement (name) @font-lock-type-face))
+     (class_name_statement (name) @font-lock-type-face)
+     (class_definition (name) @font-lock-type-face))
 
    :language 'gdscript
    :feature 'definition
-   '((function_definition (name) @font-lock-function-name-face)
-     (class_definition (name) @font-lock-function-name-face))
+   '((function_definition (name) @font-lock-function-name-face))
 
    :language 'gdscript
    :feature 'annotation
@@ -160,7 +160,7 @@ It must be a function with two arguments: TYPE and NAME.")
 
    :language 'gdscript
    :feature 'function
-   '((call (identifier) @font-lock-function-call-face (:match "preload" @font-lock-function-call-face))
+   '((call (identifier) @font-lock-builtin-face (:match "preload" @font-lock-builtin-face))
      (call (identifier) @font-lock-function-call-face)
      (attribute_call (identifier) @font-lock-function-call-face))
 

--- a/gdscript-ts-mode.el
+++ b/gdscript-ts-mode.el
@@ -87,10 +87,10 @@ It must be a function with two arguments: TYPE and NAME.")
 ;;; Types
 
 (defvar gdscript-ts--builtin-type-regex
-  "\\`\\(Vector2\\|Vector2i\\|Vector3\\|Vector3i\\|Vector4\\|Vector4i\\|Color\\|Rect2\\|Rect2i\\|Array\\|Basis\\|Dictionary\\|Plane\\|Quat\\|RID\\|Rect3\\|Transform\\|Transform2D\\|Transform3D\\|AABB\\|String\\|Color\\|NodePath\\|PoolByteArray\\|PoolIntArray\\|PoolRealArray\\|PoolStringArray\\|PoolVector2Array\\|PoolVector3Array\\|PoolColorArray\\|bool\\|int\\|float\\|Signal\\|Callable\\|StringName\\|Quaternion\\|Projection\\|PackedByteArray\\|PackedInt32Array\\|PackedInt64Array\\|PackedFloat32Array\\|PackedFloat64Array\\|PackedStringArray\\|PackedVector2Array\\|PackedVector2iArray\\|PackedVector3Array\\|PackedVector3iArray\\|PackedVector4Array\\|PackedColorArray\\|JSON\\|UPNP\\|OS\\|IP\\|JSONRPC\\|XRVRS\\)\\'")
+  "\\`\\(int\\|bool\\|float\\|void\\|Vector2\\|Vector2i\\|Vector3\\|Vector3i\\|Vector4\\|Vector4i\\|Color\\|Rect2\\|Rect2i\\|Array\\|Basis\\|Dictionary\\|Plane\\|Quat\\|RID\\|Rect3\\|Transform\\|Transform2D\\|Transform3D\\|AABB\\|String\\|Color\\|NodePath\\|PoolByteArray\\|PoolIntArray\\|PoolRealArray\\|PoolStringArray\\|PoolVector2Array\\|PoolVector3Array\\|PoolColorArray\\|bool\\|int\\|float\\|Signal\\|Callable\\|StringName\\|Quaternion\\|Projection\\|PackedByteArray\\|PackedInt32Array\\|PackedInt64Array\\|PackedFloat32Array\\|PackedFloat64Array\\|PackedStringArray\\|PackedVector2Array\\|PackedVector2iArray\\|PackedVector3Array\\|PackedVector3iArray\\|PackedVector4Array\\|PackedColorArray\\|JSON\\|UPNP\\|OS\\|IP\\|JSONRPC\\|XRVRS\\)\\'")
 
 (defvar gdscript-ts--type-regex
-  "\\`\\(int\\|bool\\|float\\|void\\|[A-Z][a-zA-Z0-9_]*[a-z][a-zA-Z0-9_]*\\)\\'")
+  "\\`[A-Z][a-zA-Z0-9_]*[a-z][a-zA-Z0-9_]*\\'")
 
 ;;; Constants
 

--- a/gdscript-ts-mode.el
+++ b/gdscript-ts-mode.el
@@ -86,6 +86,9 @@ It must be a function with two arguments: TYPE and NAME.")
 
 ;;; Types
 
+(defvar gdscript-ts--builtin-type-regex
+  "\\`\\(Vector2\\|Vector2i\\|Vector3\\|Vector3i\\|Vector4\\|Vector4i\\|Color\\|Rect2\\|Rect2i\\|Array\\|Basis\\|Dictionary\\|Plane\\|Quat\\|RID\\|Rect3\\|Transform\\|Transform2D\\|Transform3D\\|AABB\\|String\\|Color\\|NodePath\\|PoolByteArray\\|PoolIntArray\\|PoolRealArray\\|PoolStringArray\\|PoolVector2Array\\|PoolVector3Array\\|PoolColorArray\\|bool\\|int\\|float\\|Signal\\|Callable\\|StringName\\|Quaternion\\|Projection\\|PackedByteArray\\|PackedInt32Array\\|PackedInt64Array\\|PackedFloat32Array\\|PackedFloat64Array\\|PackedStringArray\\|PackedVector2Array\\|PackedVector2iArray\\|PackedVector3Array\\|PackedVector3iArray\\|PackedVector4Array\\|PackedColorArray\\|JSON\\|UPNP\\|OS\\|IP\\|JSONRPC\\|XRVRS\\)\\'")
+
 (defvar gdscript-ts--type-regex
   "\\`\\(int\\|bool\\|float\\|void\\|[A-Z][a-zA-Z0-9_]*[a-z][a-zA-Z0-9_]*\\)\\'")
 
@@ -128,17 +131,18 @@ It must be a function with two arguments: TYPE and NAME.")
 
    :language 'gdscript
    :feature 'type
-   `(((identifier) @font-lock-type-face
+   `(((identifier) @font-lock-builtin-face
+      (:match ,gdscript-ts--builtin-type-regex @font-lock-builtin-face))
+     (get_node) @font-lock-builtin-face
+     ((identifier) @font-lock-type-face
       (:match ,gdscript-ts--type-regex @font-lock-type-face))
      (enum_definition name: (_) @font-lock-type-face)
-     (class_name_statement (name) @font-lock-type-face)
-     (get_node) @font-lock-type-face)
+     (class_name_statement (name) @font-lock-type-face))
 
    :language 'gdscript
    :feature 'definition
    '((function_definition (name) @font-lock-function-name-face)
-     (class_definition (name) @font-lock-function-name-face)
-     (parameters (identifier) @font-lock-variable-name-face))
+     (class_definition (name) @font-lock-function-name-face))
 
    :language 'gdscript
    :feature 'annotation
@@ -147,7 +151,8 @@ It must be a function with two arguments: TYPE and NAME.")
 
    :language 'gdscript
    :feature 'keyword
-   `((_ _ @font-lock-keyword-face (:match ,gdscript-ts--keyword-regex @font-lock-keyword-face)))
+   `((ERROR _ @font-lock-keyword-face (:match ,gdscript-ts--keyword-regex @font-lock-keyword-face))
+     (_ _ @font-lock-keyword-face (:match ,gdscript-ts--keyword-regex @font-lock-keyword-face)))
 
    :language 'gdscript
    :feature 'string
@@ -155,7 +160,8 @@ It must be a function with two arguments: TYPE and NAME.")
 
    :language 'gdscript
    :feature 'function
-   '((call (identifier) @font-lock-function-call-face)
+   '((call (identifier) @font-lock-function-call-face (:match "preload" @font-lock-function-call-face))
+     (call (identifier) @font-lock-function-call-face)
      (attribute_call (identifier) @font-lock-function-call-face))
 
    :language 'gdscript

--- a/gdscript-ts-mode.el
+++ b/gdscript-ts-mode.el
@@ -68,13 +68,14 @@ It must be a function with two arguments: TYPE and NAME.")
   (if (string= type "class")
       "*class definition*"
     "*function definition*"))
+
 
 ;;; Keywords
 
 (defvar gdscript-ts--keyword-regex
   (rx bot (| "func" "var" "const" "set" "get" "setget" "signal" "extends"
-             "match" "if" "elif" "else" "while" "break" "continue" "pass"
-             "return" "when" "yield" "await"
+             "match" "if" "elif" "else" "for" "in" "while" "break" "continue" 
+             "pass" "return" "when" "yield" "await"
              "class" "class_name" "abstract" "is" "onready" "tool" "static"
              "export" "as" "void" "enum" "assert" "breakpoint"
              "sync" "remote" "master" "puppet"

--- a/gdscript-ts-mode.el
+++ b/gdscript-ts-mode.el
@@ -123,6 +123,7 @@ It must be a function with two arguments: TYPE and NAME.")
    :feature 'type
    `(((identifier) @font-lock-type-face (:match ,gdscript-ts--type-regex @font-lock-type-face))
      (enum_definition name: (_) @font-lock-type-face)
+     (class_name_statement (name) @font-lock-type-face)
      (get_node) @font-lock-type-face)
 
    :language 'gdscript

--- a/gdscript-ts-mode.el
+++ b/gdscript-ts-mode.el
@@ -72,12 +72,23 @@ It must be a function with two arguments: TYPE and NAME.")
 ;;; Keywords
 
 (defvar gdscript-ts--treesit-keywords '("and" "as" "break" "class" "class_name"
-                                        "const" "continue" "elif" "else" "enum" "export" "extends" "for" "func" "if" "in" "is"
-                                        "master" "match" "not" "onready" "or" "pass"  "puppet" "remote" "remotesync" "return" "setget" "signal"
+                                        "const" "continue" "elif" "else" "enum"
+                                        "export" "extends" "for" "func" "if" "in" "is"
+                                        "master" "match" "not" "onready" "or" "pass"
+                                        "puppet" "remote" "remotesync" "return" "setget" "signal"
                                         "var" "while"))
 
-
 ;;; Setting
+
+(defvar gdscript-ts--type-regex "\\`[A-Z][a-zA-Z0-9_]*[a-z][a-zA-Z0-9_]*\\'")
+
+(defvar gdscript-ts--constant-regex "\\`[A-Z_][A-Z0-9_]+\\'")
+
+(defvar gdscript-ts--feature-list
+  '(( comment definition)
+    ( keyword string type annotation)
+    ( number constant escape-sequence)
+    ( bracket delimiter function operator property)))
 
 (defvar gdscript-ts--treesit-settings
   (treesit-font-lock-rules
@@ -86,46 +97,79 @@ It must be a function with two arguments: TYPE and NAME.")
    '((comment) @font-lock-comment-face)
 
    :language 'gdscript
+   :feature 'constant
+   `(([(null) (false) (true)] @font-lock-constant-face)
+     (const_statement name: (name) @font-lock-constant-face)
+     (enumerator left: (identifier) @font-lock-constant-face)
+     ((identifier) @font-lock-constant-face
+      (:match ,gdscript-ts--constant-regex @font-lock-constant-face))
+     (variable_statement
+      name: (name) @font-lock-constant-face
+      (:match ,gdscript-ts--constant-regex @font-lock-constant-face)))
+
+   :language 'gdscript
+   :feature 'bracket
+   `(["[" "]" "(" ")" "{" "}"] @font-lock-bracket-face)
+
+   :language 'gdscript
+   :feature 'delimiter
+   `(["," ":" "."] @font-lock-delimiter-face)
+
+   :language 'gdscript
+   :feature 'type
+   `(((identifier) @font-lock-type-face
+      (:match ,(rx (| "int" "bool" "float" "void")) @font-lock-type-face))
+     ((identifier) @font-lock-type-face
+      (:match ,gdscript-ts--type-regex @font-lock-type-face))
+     (enum_definition name: (_) @font-lock-type-face)
+     (get_node) @font-lock-type-face)
+
+   :language 'gdscript
    :feature 'definition
    '((function_definition (name) @font-lock-function-name-face)
-     (class_definition
-      (name) @font-lock-function-name-face)
+     (class_definition (name) @font-lock-function-name-face)
      (parameters (identifier) @font-lock-variable-name-face))
 
    :language 'gdscript
    :feature 'keyword
    `(([,@gdscript-ts--treesit-keywords] @font-lock-keyword-face)
-     ([(false) (true)] @font-lock-keyword-face))
+     (call (identifier) @font-lock-keyword-face
+           (:match ,(rx (| "yield")) @font-lock-keyword-face))
+     (attribute (identifier) @font-lock-keyword-face
+                (:match ,(rx (| "self")) @font-lock-keyword-face))
+     (await_expression "await" @font-lock-keyword-face)
+     (static_keyword) @font-lock-keyword-face)
 
    :language 'gdscript
    :feature 'string
    '((string) @font-lock-string-face)
 
    :language 'gdscript
-   :feature 'type
-   '(((type) @font-lock-type-face)
-     (get_node) @font-lock-type-face)
-
    :feature 'function
-   :language 'gdscript
    '((call (identifier) @font-lock-function-call-face)
      (attribute_call (identifier) @font-lock-function-call-face))
 
    :language 'gdscript
-   :feature 'variable
-   '((_ (name) @font-lock-variable-name-face))
-
    :feature 'number
-   :language 'gdscript
    '(([(integer) (float)] @font-lock-number-face))
 
-   :feature 'property
    :language 'gdscript
+   :feature 'property
    '((attribute (identifier) (identifier) @font-lock-property-use-face))
 
    :feature 'operator
    :language 'gdscript
-   `(["+" "-" "*" "/" "^" ">" "<" "="] @font-lock-operator-face)))
+   `(["+" "+="   "-" "-=" "*" "*=" "/" "/=" "^"  "^="  ">"  ">="
+      "<" "<="   "|" "|=" "%" "%=" "&" "&=" ">>" ">>=" "<<" "<<="
+      "||" "&&" "==" "!=" "->" "~" "="] @font-lock-operator-face)
+
+   :language 'gdscript
+   :feature 'escape-sequence
+   '((escape_sequence) @font-lock-escape-face)
+
+   :language 'gdscript
+   :feature 'annotation
+   '((annotation "@" @font-lock-preprocessor-face (identifier) @font-lock-preprocessor-face))))
 
 
 ;;; Funtion
@@ -220,10 +264,7 @@ Similar to `gdscript-imenu-create-index' but use tree-sitter."
   :syntax-table gdscript-mode-syntax-table
   (when (treesit-ready-p 'gdscript)
     (treesit-parser-create 'gdscript)
-    (setq-local treesit-font-lock-feature-list
-                '(( comment definition)
-                  ( keyword string type)
-                  ( function variable number property operator)))
+    (setq-local treesit-font-lock-feature-list gdscript-ts--feature-list)
     (setq-local treesit-font-lock-settings gdscript-ts--treesit-settings)
     ;;; TODO: create-imenu
     (setq-local imenu-create-index-function


### PR DESCRIPTION
 * Support for annotations
 * Support for punctuation
 * More operators
 * Regex-based types and keywords, added missing ones
 * Regex-based constants
 * Moved feature list to **defvar** so it's possible to modify in user configs
 * Removed variable highlighting for more consistency among different color themes
 
<details>
  <summary>Before/After Screenshots</summary>

![Kanagawa](https://github.com/user-attachments/assets/ba3c97b7-b713-462b-b906-471cb9a24820)
![1337](https://github.com/user-attachments/assets/388d71d9-4c9c-4f3c-b77f-51973291f9b0)
![Xcode](https://github.com/user-attachments/assets/5ce65870-19fc-4a5a-b9b5-3b4070a4c59f)
</details>

