### PR TITLE
Filter scene select

### DIFF
--- a/gdscript-project.el
+++ b/gdscript-project.el
@@ -48,13 +48,13 @@ If current buffer is not visiting scene file return nil."
   "Find all scenes files and let user choose one. Return `nil' if user cancels selection."
   (let* ((rl (gdscript-util--find-project-configuration-file))
          (scene-list (mapcar (lambda (x) (file-relative-name x rl))
-			     (directory-files-recursively
-			      rl
-			      "^.*\\.tscn$"
-			      t
-			      (lambda (dir)
-				(not (string-match "^\\.\\(godot\\|git\\|hg\\)$"
-						   (file-relative-name dir rl)))))))
+                             (directory-files-recursively
+                              rl
+                              "^.*\\.tscn$"
+                              t
+                              (lambda (dir)
+                                (not (string-match "^\\.\\(godot\\|git\\|hg\\)$"
+                                                   (file-relative-name dir rl)))))))
          (prompt (format "Select scene to run (%s): " (buffer-name)))
          (selected-scene (gdscript-util--read scene-list prompt)))
     selected-scene))

--- a/gdscript-project.el
+++ b/gdscript-project.el
@@ -47,7 +47,14 @@ If current buffer is not visiting scene file return nil."
 (defun gdscript-project--select-scene ()
   "Find all scenes files and let user choose one. Return `nil' if user cancels selection."
   (let* ((rl (gdscript-util--find-project-configuration-file))
-         (scene-list (mapcar (lambda (x) (file-relative-name x rl)) (directory-files-recursively rl ".*.tscn" t)))
+         (scene-list (mapcar (lambda (x) (file-relative-name x rl))
+			     (directory-files-recursively
+			      rl
+			      "^.*\\.tscn$"
+			      t
+			      (lambda (dir)
+				(not (string-match "^\\.\\(godot\\|git\\|hg\\)$"
+						   (file-relative-name dir rl)))))))
          (prompt (format "Select scene to run (%s): " (buffer-name)))
          (selected-scene (gdscript-util--read scene-list prompt)))
     selected-scene))


### PR DESCRIPTION
When working on `foo.tscn`,
`.godot/` will contain `foo.tscn-folding` and `foo.tscn-editstate` files.

These are picked up by `gdscript-project--select-scene`, which is used when calling `gdscript-run-current-scene` with a prefix argument. (`C-u <f6>`). 

This hinders searching and completion when I type "foo" as multiple non-scene files show up.

This PR enforces that the file *must end* in ".tscn" *exactly*. 

I also added a PREDICATE to avoid unnecessarily descending into `.godot/`, `.git/` and `.hg` directories when searching for scenes.