### PR TITLE
Add Directory Local Variables for indentation

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,7 @@
+;;; Directory Local Variables         -*- no-byte-compile: t; -*-
+;;; For more information see (info "(emacs) Directory Variables")
+
+((nil
+  (indent-tabs-mode . nil))
+ (makefile-mode
+  (indent-tabs-mode . t)))


### PR DESCRIPTION
Close #190

Set `.dir-locals.el` to use spaces everywhere _except_ in the Makefile.