### PR TITLE
Only use ido-completing-read if user has ido-mode enabled

### DIFF
--- a/gdscript-utils.el
+++ b/gdscript-utils.el
@@ -146,8 +146,6 @@ PROMPT is prompt for read command. Return `nil' if user aborts."
   (let* ((p (if prompt prompt "Options"))
          (result (cond ((featurep 'projectile)
                         (projectile-completing-read (format "%s: " p) items))
-                       ((fboundp 'ivy-read)
-                        (ivy-read (format "%s: " p) items))
                        (ido-mode
                         (ido-completing-read (format "%s: " p) items))
                        (t

--- a/gdscript-utils.el
+++ b/gdscript-utils.el
@@ -148,10 +148,10 @@ PROMPT is prompt for read command. Return `nil' if user aborts."
                         (projectile-completing-read (format "%s: " p) items))
                        ((fboundp 'ivy-read)
                         (ivy-read (format "%s: " p) items))
-                       ((fboundp 'ido-completing-read)
+                       (ido-mode
                         (ido-completing-read (format "%s: " p) items))
                        (t
-                        (completing-read (format "%s (hit TAB to auto-complete): " p) items nil t)))))
+                        (completing-read (format "%s: " p) items nil t)))))
     (if quit-flag nil result)))
 
 (defmacro gdscript-util--with-available-hydra (&rest body)


### PR DESCRIPTION
## Problem

`(fboundp 'ido-completing-read)` always succeeds,
since `ido-mode` is built-in, it's always bound.

So if the user does not use projectile, ivy or ido it never falls back to basic `completing-read` with the user's completion framework of choice.

## Fix

This commit changes the predicate so ido is only used if `ido-mode` is enabled. 

This felt like the best way to go as ido users will get to use their completion framework. But users of say, vertico, fido, icomplete or vanilla completion can use their own frameworks.

## Additional Edits

1. I also removed the "(Hit TAB to complete)" because personally, I didn't like it taking up so much space in the prompt. Also from a technical point it's not necessarily true. It was a hard-coded string that doesn't account for user's rebinding keys.

2. I have also removed the ivy-specific check. `ivy-mode` overrides the mechanisms underlying `completing-read`, so ivy users are already covered just by using `completing-read` which is the final condition.

Behaviourally, ivy users should not be affected, unless for some reason they have both `ivy-mode` and `ido-mode` enabled at the same time.

## Note

**PS:** Would you prefer I make issues before I post these? I'm mostly just tweaking it for personal use then submitting PRs if it's good.

