### PR TITLE
fix: Avoid .dir-locals.el being packaged

### DIFF
--- a/Eask
+++ b/Eask
@@ -8,7 +8,7 @@
 (keywords "languages")
 
 (package-file "gdscript-mode.el")
-(files "*.el")
+(files "gdscript-*.el")
 
 (script "test" "echo \"Error: no test specified\" && exit 1")
 


### PR DESCRIPTION
Avoid:

```
Compiling /Users/runner/work/emacs-gdscript-mode/emacs-gdscript-mode/.dir-locals.el... skipped ✗

In toplevel form:
.dir-locals.el:1:1: Warning: file has no ‘lexical-binding’ directive on its first line
```

and

```
`.dir-locals.el` with checkdoc (0.6.2)
.dir-locals.el:0: The first line should be of the form: ";;; package --- Summary"
.dir-locals.el:0: You should have a section marked ";;; Commentary:"
.dir-locals.el:4: You should have a section marked ";;; Code:"
.dir-locals.el:7: The footer should be: (provide ’.dir-locals)\n;;; .dir-locals.el ends here
```