### PR TITLE
Define easy-menu for gdscript-mode

### DIFF
--- a/gdscript-mode.el
+++ b/gdscript-mode.el
@@ -112,6 +112,33 @@
     map)
   "Keymap for `gdscript-mode'.")
 
+(easy-menu-define gdscript-mode-menu gdscript-mode-map
+  "Menu for GDScript mode."
+  '("GDScript"
+    ("Script"
+     ["Format all" gdscript-format-buffer
+      :active (executable-find gdscript-gdformat-executable)
+      :help "Format the buffer using GDFormat, if installed"]
+     ["Format region" gdscript-format-region
+      :active (executable-find gdscript-gdformat-executable)
+      :help "Format the selected region using GDFormat, if installed"])
+    ("Scene"
+     ["Open" gdscript-godot-edit-current-scene
+      :help "Open the current scene in the Godot editor"]
+     ["Run current" gdscript-godot-run-current-scene
+      :help "Run the current scene"])
+    ("Project"
+     ["Open" gdscript-godot-open-project-in-editor
+      :help "Open the project in the Godot editor"]
+     ["Run" gdscript-godot-run-project
+      :help "Run the project's main scene"])
+    ("Help"
+     ["Online documentation" (gdscript-docs-browse-api t)
+      :help "Browse Godot Docs, online"]
+     ["Local documentation" gdscript-docs-browse-api
+      :active (not (equal "" gdscript-docs-local-path))
+      :help "Browse local copy of Godot Docs, if it exists"])))
+
 (defun gdscript-hideshow-forward-sexp-function (_arg)
   "Gdscript specific `forward-sexp' function for function `hs-minor-mode'.
 Argument ARG is ignored."


### PR DESCRIPTION
## Changes
Adds an Easy Menu with the following options:

```
GDScript > Script  > Format all
                     Format region
           Scene   > Open
                     Run current
           Project > Open
                     Run
           Help    > Online documentation
                     Local documentation
```

Easy Menus are accessed:
- By clicking `gdscript` on the modeline
- By right clicking, *if* you enable `context-menu-mode`


Some options are only active if you meet certain criteria (to avoid confusing users):
- `Help > Local documentation` is active if `gdscript-docs-local-path` is a non-empty string.
- `Script > Format *` options are active if `gdscript-gdformat-executable` points to an executable in your `exec path`

## Not Included

The following have not been included **yet**. This is because they require more significant changes to be implemented cleanly, but I am interested in added them in future PRs.

### Debug options

I want to include toggleable debug options and the ability to run with debug. The issues with this are as follows:

- debug options are tightly coupled to `gdscript-hydra` currently. It would probably require extracting some of the logic to more generic functions within `gdscript-godot` first.
- There are 4 `debug-*` options missing:
    - `debug-paths`
    - `debug-avoidance`
    - `debug-stringnames`
    - `debug-canvas-item-redraw`
  I would want to add these first, to simplify incoming PRs.

### `Script > Run` option

Before adding this button I want it to be obvious to users when it wont work. Ideally, I'd like it to _just know_ when a script doesn't extend `MainLoop` or `SceneTree`.

It should probably also be hidden if `ag` isn't installed, since the function has been hardcoded to not work with any other `grep` command.