### PR TITLE
Add custom variable for godot config directory

### DIFF
--- a/gdscript-eglot.el
+++ b/gdscript-eglot.el
@@ -42,15 +42,7 @@
   :type 'integer
   :group 'gdscript-eglot)
 
-(defun gdscript-eglot--get-config-dir ()
-  "Get system-specific directory with Godot configuration files."
-  (if gdscript-godot-config-dir (expand-file-name gdscript-godot-config-dir)
-    (pcase system-type
-      ('darwin (expand-file-name "~/Library/Application Support/Godot/"))
-      ('windows-nt (file-name-concat (getenv "APPDATA") "Godot"))
-      ('gnu/linux (file-name-concat
-                   (or (getenv "XDG_CONFIG_HOME") (expand-file-name "~/.config"))
-                   "godot")))))
+
 
 (defun gdscript-eglot--extract-port (editor-settings-file)
   "Extract LSP port from Godot EDITOR-SETTINGS-FILE.
@@ -79,7 +71,7 @@ definitions of HOST, PORT, and INTERACTIVE.
 For more context, see
 https://lists.gnu.org/archive/html/bug-gnu-emacs/2023-04/msg01070.html."
   (save-excursion
-    (let* ((config-dir (gdscript-eglot--get-config-dir))
+    (let* ((config-dir (gdscript-godot--get-config-dir))
            (settings-file (file-name-concat
                            config-dir
                            (format "editor_settings-%s.tres"

--- a/gdscript-eglot.el
+++ b/gdscript-eglot.el
@@ -28,6 +28,7 @@
 
 ;;; Code:
 
+(require 'gdscript-godot)
 (require 'gdscript-utils)
 
 ;;;###autoload
@@ -43,12 +44,13 @@
 
 (defun gdscript-eglot--get-config-dir ()
   "Get system-specific directory with Godot configuration files."
-  (pcase system-type
-    ('darwin (expand-file-name "~/Library/Application Support/Godot/"))
-    ('windows-nt (file-name-concat (getenv "APPDATA") "Godot"))
-    ('gnu/linux (file-name-concat
-                 (or (getenv "XDG_CONFIG_HOME") (expand-file-name "~/.config"))
-                 "godot"))))
+  (if gdscript-godot-config-dir (expand-file-name gdscript-godot-config-dir)
+    (pcase system-type
+      ('darwin (expand-file-name "~/Library/Application Support/Godot/"))
+      ('windows-nt (file-name-concat (getenv "APPDATA") "Godot"))
+      ('gnu/linux (file-name-concat
+                   (or (getenv "XDG_CONFIG_HOME") (expand-file-name "~/.config"))
+                   "godot")))))
 
 (defun gdscript-eglot--extract-port (editor-settings-file)
   "Extract LSP port from Godot EDITOR-SETTINGS-FILE.

--- a/gdscript-godot.el
+++ b/gdscript-godot.el
@@ -37,6 +37,21 @@
 (require 'gdscript-utils)
 
 ;;;###autoload
+(defgroup gdscript-godot nil
+  "Configurations in gdscript related to the Godot editor'."
+  :group 'gdscript)
+
+;;;###autoload
+(defcustom gdscript-godot-config-dir nil
+  "The directory containing the Godot editor's configuration files.
+
+If `gdscript-mode` is unable to find your config directory,
+you may set this variable to an exact path."
+  :type '(choice (const :tag "Detect config automatically" nil)
+                 (string :tag "Filepath"))
+  :group 'gdscript-godot)
+
+;;;###autoload
 (defvar gdscript-godot--debug-options-hydra :not-list)
 
 (defvar gdscript-godot--debug-selected-option 1)

--- a/gdscript-godot.el
+++ b/gdscript-godot.el
@@ -76,6 +76,16 @@ DEBUG-OPTIONS will be set either by Hydra, or by prefix argument selection."
           (,debug-options (if use-hydra-options gdscript-godot--debug-options-hydra prefix-options)))
      ,@body))
 
+(defun gdscript-godot--get-config-dir ()
+  "Get system-specific directory with Godot configuration files."
+  (if gdscript-godot-config-dir (expand-file-name gdscript-godot-config-dir)
+    (pcase system-type
+      ('darwin (expand-file-name "~/Library/Application Support/Godot/"))
+      ('windows-nt (file-name-concat (getenv "APPDATA") "Godot"))
+      ('gnu/linux (file-name-concat
+                   (or (getenv "XDG_CONFIG_HOME") (expand-file-name "~/.config"))
+                   "godot")))))
+
 (defun gdscript-godot--run-command (&rest arguments)
   "Run a Godot process with ARGUMENTS.
 


### PR DESCRIPTION
Close #170

## Adds `gdscript-godot-config-dir`

This solves issues where the Godot config directory is stored in unconventional locations (See #170).

When the variable is specified, check that location only. Otherwise use the existing functionality to find it.

## Moves `gdscript-eglot--get-config-dir` to `gdscript-godot`

This isn't necessary for this PR but I want to move this to a more generic location as the Godot config could be used to achieve a lot of *Out of the Box*™ functionality.

Instead of asking the user 
- "Hey, do you want tabs/spaces?" Just read their config.
- "What about ~indentation width~?" config.
- ~"type hinted snippets?"~ **CONFIG**.