### PR TITLE
Detect project version automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,18 +207,18 @@ and the GDScript language server which is built into Godot.
 
 To use the LSP with `eglot`, you need to install `eglot` on top
 of `gdscript-mode`, if using an Emacs version earlier than 29.
-After installation, `eglot` can be connected on startup by adding
-`eglot-ensure` as a hook on `gdscript-mode-hook`.
 
-Note that, due to language server changes made in Godot 4, usage
-with Godot 3 requires `gdscript-eglot-version` to be customized to 3.
+After installation, `eglot` can be connected on startup by adding:
 
-An example configuration for Godot 3 usage with `use-package`:
+```elisp
+(add-hook 'gdscript-mode-hook 'eglot-ensure)
+```
+
+Alternatively, with `use-package`:
 
 ```elisp
 (use-package gdscript-mode
-  :hook (gdscript-mode . eglot-ensure)
-  :custom (gdscript-eglot-version 3))
+  :hook (gdscript-mode . eglot-ensure))
 ```
 
 To use the LSP with `lsp-mode`, you need to install `lsp-mode`

--- a/gdscript-eglot.el
+++ b/gdscript-eglot.el
@@ -28,15 +28,12 @@
 
 ;;; Code:
 
+(require 'gdscript-utils)
+
 ;;;###autoload
 (defgroup gdscript-eglot nil
   "Configurations in gdscript related to `eglot'."
   :group 'gdscript)
-
-;;;###autoload
-(defcustom gdscript-eglot-version "4.5"
-  "The version of godot in use."
-  :type 'string)
 
 ;;;###autoload
 (defcustom gdscript-eglot-default-lsp-port 6005
@@ -83,7 +80,8 @@ https://lists.gnu.org/archive/html/bug-gnu-emacs/2023-04/msg01070.html."
     (let* ((config-dir (gdscript-eglot--get-config-dir))
            (settings-file (file-name-concat
                            config-dir
-                           (format "editor_settings-%s.tres" gdscript-eglot-version))))
+                           (format "editor_settings-%s.tres"
+                                   (gdscript-util--get-godot-project-version)))))
       (when-let* ((port (gdscript-eglot--extract-port settings-file)))
         (list "localhost" port)))))
 

--- a/gdscript-utils.el
+++ b/gdscript-utils.el
@@ -121,7 +121,8 @@ WARNING: the Godot project must exist for this function to work."
     (if (re-search-forward "config_version=\\(3\\|4\\)" nil t) ; Godot 3.0 uses 3, Godot 3.6.2 uses 4
         "3"
       (if (re-search-forward "config/features=PackedStringArray\(\"\\([^,\)]*\\)\"" nil t)
-          (match-string 1)
+          (let ((version (match-string 1)))
+            (if (string-prefix-p "4.0" version) "4" version))
         (error "Could not find the project version")))))
 
 (defun gdscript-util--get-godot-buffer-name (&optional editor)

--- a/gdscript-utils.el
+++ b/gdscript-utils.el
@@ -113,6 +113,17 @@ WARNING: the Godot project must exist for this function to work."
         (match-string 1)
       (error "Could not find the name of the project"))))
 
+(defun gdscript-util--get-godot-project-version ()
+  "Retrieve the project name from Godot's configuration file."
+  (with-temp-buffer
+    (insert-file-contents (concat (gdscript-util--find-project-configuration-file) "project.godot"))
+    (goto-char (point-min))
+    (if (re-search-forward "config_version=\\(3\\|4\\)" nil t) ; Godot 3.0 uses 3, Godot 3.6.2 uses 4
+        "3"
+      (if (re-search-forward "config/features=PackedStringArray\(\"\\([^,\)]*\\)\"" nil t)
+          (match-string 1)
+        (error "Could not find the project version")))))
+
 (defun gdscript-util--get-godot-buffer-name (&optional editor)
   "Return buffer name for godot's stdout/stderr output."
   (format (if editor "*godot - %s - Editor*" "*godot - %s*") (gdscript-util--get-godot-project-name)))


### PR DESCRIPTION
## Add `gdscript-util--get-godot-project-version`
Returns a string version that the current project is running under.

I downloaded several versions to check `config_version`:
- Godot 3.0 uses `config_version=3`
- Godot 3.6.2 uses `config_version=4`
- Godot 4.0 `config_version=5`
- Godot 4.6 `config_version=5`

If version is 3 or 4, return "3", otherwise read `config/features` [just like the vc-code extension](https://github.com/godotengine/godot-vscode-plugin/blob/723e2f4e7e9b48d46a52628a7dbc40a8391ede43/src/utils/godot_utils.ts#L67-L95).

## Remove `gdscript-eglot-version`

No longer necessary, project version is detected automatically.

Removing it also saves the maintenance burden of having to update the default value on new releases.

## Update README

Users don't need to concern themselves with manually setting it for 3.x so this section has been trimmed to what matters.