### PR TITLE
Capitalize mode line lighters

### DIFF
--- a/gdscript-mode.el
+++ b/gdscript-mode.el
@@ -180,7 +180,7 @@ already marked."
   (gdscript-nav-end-of-defun))
 
 ;;;###autoload
-(define-derived-mode gdscript-mode prog-mode "gdscript"
+(define-derived-mode gdscript-mode prog-mode "GDScript"
   "Major mode for editing Godot GDScript files."
   (setq-local tab-width gdscript-tab-width)
   (setq-local indent-tabs-mode gdscript-use-tab-indents)

--- a/gdscript-ts-mode.el
+++ b/gdscript-ts-mode.el
@@ -284,7 +284,7 @@ Similar to `gdscript-imenu-create-index' but use tree-sitter."
     (gdscript-ts--imenu-treesit-create-index-1 tree)))
 
 ;;;###autoload
-(define-derived-mode gdscript-ts-mode gdscript-mode "Gdscript"
+(define-derived-mode gdscript-ts-mode gdscript-mode "GDScript"
   "Major mode for editing gdscript files, using tree-sitter library.
 
 \\{gdscript-ts-mode-map}"


### PR DESCRIPTION
## Capitalize Mode Line Lighters

Mode line lighters in Emacs are typically capitalized:
- Elisp
- Flymake
- Eldoc

The list could go on but 3 will do.

This commit updates the mode line lighters to match the capitalization used in the official Godot documentation.