### PR TITLE
Update `gdscript-ts-mode` requires to Emacs 28.1

### DIFF
--- a/gdscript-ts-mode.el
+++ b/gdscript-ts-mode.el
@@ -7,7 +7,7 @@
 ;;             Jen-Chieh Shen <jcs090218@gmail.com>
 
 ;; Keywords: languages
-;; Package-Requires: ((emacs "26.3"))
+;; Package-Requires: ((emacs "28.1"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
## Update GDScript TS Mode Minimum Requirement

`gdscript-ts-mode` is derived from `gdscript-mode`. if `gdscript-mode` requires Emacs 28.1,
then`gdscript-ts-mode` cannot work on an earlier version.

This commit updates the version to match.