### PR TITLE
Ignore package-vc autoloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ dist/
 
 #emacs projectile
 .projectile
+
+# Emacs package-vc files
+*-autoloads.el
+*-pkg.el


### PR DESCRIPTION
I use `gdscript-mode` through `package-vc-install`. 

This allows me to use it as a package *and* contribute to it from the same install.

This commit ignores the files related to using it as a package, which should not be part of version control.