### PR TITLE
Remove keybind that doesn't work

### DIFF
--- a/gdscript-mode.el
+++ b/gdscript-mode.el
@@ -74,7 +74,6 @@
     ;; Indent specific
     (define-key map "\177" 'gdscript-indent-dedent-line-backspace)
     (define-key map (kbd "<backtab>") 'gdscript-indent-dedent-line)
-    (define-key map (kbd "\t") 'company-complete)
     ;; Insertion.
     (define-key map (kbd "C-c i") 'gdscript-completion-insert-file-path-at-point)
     ;; Formatting.


### PR DESCRIPTION
> [!NOTE] 
> **Since this keybinding never worked**, removing it does not break backwards compatibility.

`\t` is set to `company-complete` but `\t` does not map to `<tab>` as intended. 
Check in any `gdscript-mode` buffer with`C-h m`. There is no binding set for `company-complete` anywhere.

Instead of fixing it, I opted to remove it for two reasons:
    1. Not everyone uses `company`.
    2. `company-mode` already overrides completion. So we have no reason to do it ourselves.

