### PR TITLE
Use readable name for <backspace> binding

### DIFF
--- a/gdscript-mode.el
+++ b/gdscript-mode.el
@@ -72,7 +72,7 @@
     (define-key map [remap mark-defun] 'gdscript-mark-defun)
     (define-key map (kbd "C-c C-j") 'imenu)
     ;; Indent specific
-    (define-key map "\177" 'gdscript-indent-dedent-line-backspace)
+    (define-key map (kbd "<backspace>") 'gdscript-indent-dedent-line-backspace)
     (define-key map (kbd "<backtab>") 'gdscript-indent-dedent-line)
     (define-key map (kbd "\t") 'company-complete)
     ;; Insertion.


### PR DESCRIPTION
> [!NOTE]
> This does not change the keybinding at all. It is still bound to `DEL` a.k.a. `backspace`

This PR simply replaces the escape code: `\177` with `<backspace>` so it's readable simply by looking at the code.