### PR TITLE
Simplify keymap defintion using `defvar-keymap`

### DIFF
--- a/gdscript-mode.el
+++ b/gdscript-mode.el
@@ -106,7 +106,7 @@
   "<f7>" 'gdscript-debug-continue
   "C-c C-d s" 'gdscript-debug-step
   ;; Debugger Hydra
-  "C-c n" 'gdscript-debug-hydra)
+  "C-c C-n" 'gdscript-debug-hydra)
 
 (easy-menu-define gdscript-mode-menu gdscript-mode-map
   "Menu for GDScript mode."

--- a/gdscript-mode.el
+++ b/gdscript-mode.el
@@ -74,7 +74,7 @@
   "<backspace>" 'gdscript-indent-dedent-line-backspace
   "<backtab>" 'gdscript-indent-dedent-line
   ;; Insertion.
-  "C-c i" 'gdscript-completion-insert-file-path-at-point
+  "C-c C-i" 'gdscript-completion-insert-file-path-at-point
   ;; Formatting.
   "C-c C-f r" 'gdscript-format-region
   "C-c C-f b" 'gdscript-format-buffer

--- a/gdscript-mode.el
+++ b/gdscript-mode.el
@@ -7,7 +7,7 @@
 ;; Maintainer: Jen-Chieh Shen <jcs090218@gmail.com>
 ;; URL: https://github.com/godotengine/emacs-gdscript-mode/
 ;; Version: 1.5.0
-;; Package-Requires: ((emacs "28.1"))
+;; Package-Requires: ((emacs "29.1"))
 ;; Created: Jan 2020
 ;; Keywords: languages
 

--- a/gdscript-mode.el
+++ b/gdscript-mode.el
@@ -63,53 +63,50 @@
     (push (cons 'gdscript-mode #'gdscript-eglot-contact)
           eglot-server-programs)))
 
-(defvar gdscript-mode-map
-  (let ((map (make-sparse-keymap)))
-    ;; Movement
-    (define-key map [remap backward-sentence] 'gdscript-nav-backward-block)
-    (define-key map [remap forward-sentence] 'gdscript-nav-forward-block)
-    (define-key map [remap backward-up-list] 'gdscript-nav-backward-up-list)
-    (define-key map [remap mark-defun] 'gdscript-mark-defun)
-    (define-key map (kbd "C-c C-j") 'imenu)
-    ;; Indent specific
-    (define-key map (kbd "<backspace>") 'gdscript-indent-dedent-line-backspace)
-    (define-key map (kbd "<backtab>") 'gdscript-indent-dedent-line)
-    ;; Insertion.
-    (define-key map (kbd "C-c i") 'gdscript-completion-insert-file-path-at-point)
-    ;; Formatting.
-    (define-key map (kbd "C-c C-f r") 'gdscript-format-region)
-    (define-key map (kbd "C-c C-f b") 'gdscript-format-buffer)
-    ;; Run in Godot.
-    (define-key map (kbd "C-c C-r p") 'gdscript-godot-open-project-in-editor)
-    (define-key map (kbd "C-c C-r r") 'gdscript-godot-run-project)
-    (define-key map (kbd "<f5>") 'gdscript-godot-run-project)
-    (define-key map (kbd "C-c C-r d") 'gdscript-godot-run-project-debug)
-    (define-key map (kbd "C-c C-r s") 'gdscript-godot-run-current-scene)
-    (define-key map (kbd "<f6>") 'gdscript-godot-run-current-scene)
-    (define-key map (kbd "C-c C-r q") 'gdscript-godot-run-current-scene-debug)
-    (define-key map (kbd "C-c C-r e") 'gdscript-godot-edit-current-scene)
-    (define-key map (kbd "C-c C-r x") 'gdscript-godot-run-current-script)
-    ;; Docs.
-    (define-key map (kbd "C-c C-b a") 'gdscript-docs-browse-api)
-    (define-key map (kbd "C-c C-b o") 'gdscript-docs-browse-symbol-at-point)
-    (define-key map (kbd "C-c C-b s") 'gdscript-docs-online-search-api)
-    ;; Hydra
-    (define-key map (kbd "C-c r") 'gdscript-hydra-show)
-    ;; Debugger
-    (define-key map (kbd "C-c C-d C-d s") 'gdscript-debug-display-stack-frame-vars-buffer)
-    (define-key map (kbd "C-c C-d C-d d") 'gdscript-debug-display-stack-dump-buffer)
-    (define-key map (kbd "C-c C-d C-d b") 'gdscript-debug-display-breakpoint-buffer)
-    (define-key map (kbd "C-c C-d C-d i") 'gdscript-debug-display-inspector-buffer)
-    (define-key map (kbd "<f9>") 'gdscript-debug-toggle-breakpoint)
-    (define-key map (kbd "C-c C-d q") 'gdscript-debug-make-server)
-    (define-key map (kbd "C-c C-d n") 'gdscript-debug-next)
-    (define-key map (kbd "C-c C-d c") 'gdscript-debug-continue)
-    (define-key map (kbd "<f7>") 'gdscript-debug-continue)
-    (define-key map (kbd "C-c C-d s") 'gdscript-debug-step)
-    ;; Debugger Hydra
-    (define-key map (kbd "C-c n") 'gdscript-debug-hydra)
-    map)
-  "Keymap for `gdscript-mode'.")
+(defvar-keymap gdscript-mode-map
+  :doc "Keymap for `gdscript-mode'."
+  "<remap> <backward-sentence>" 'gdscript-nav-backward-block
+  "<remap> <forward-sentence>" 'gdscript-nav-forward-block
+  "<remap> <backward-up-list>" 'gdscript-nav-backward-up-list
+  "<remap> <mark-defun>" 'gdscript-mark-defun
+  "C-c C-j" 'imenu
+  ;; Indent specific
+  "<backspace>" 'gdscript-indent-dedent-line-backspace
+  "<backtab>" 'gdscript-indent-dedent-line
+  ;; Insertion.
+  "C-c i" 'gdscript-completion-insert-file-path-at-point
+  ;; Formatting.
+  "C-c C-f r" 'gdscript-format-region
+  "C-c C-f b" 'gdscript-format-buffer
+  ;; Run in Godot.
+  "C-c C-r p" 'gdscript-godot-open-project-in-editor
+  "C-c C-r r" 'gdscript-godot-run-project
+  "<f5>" 'gdscript-godot-run-project
+  "C-c C-r d" 'gdscript-godot-run-project-debug
+  "C-c C-r s" 'gdscript-godot-run-current-scene
+  "<f6>" 'gdscript-godot-run-current-scene
+  "C-c C-r q" 'gdscript-godot-run-current-scene-debug
+  "C-c C-r e" 'gdscript-godot-edit-current-scene
+  "C-c C-r x" 'gdscript-godot-run-current-script
+  ;; Docs.
+  "C-c C-b a" 'gdscript-docs-browse-api
+  "C-c C-b o" 'gdscript-docs-browse-symbol-at-point
+  "C-c C-b s" 'gdscript-docs-online-search-api
+  ;; Hydra
+  "C-c r" 'gdscript-hydra-show
+  ;; Debugger
+  "C-c C-d C-d s" 'gdscript-debug-display-stack-frame-vars-buffer
+  "C-c C-d C-d d" 'gdscript-debug-display-stack-dump-buffer
+  "C-c C-d C-d b" 'gdscript-debug-display-breakpoint-buffer
+  "C-c C-d C-d i" 'gdscript-debug-display-inspector-buffer
+  "<f9>" 'gdscript-debug-toggle-breakpoint
+  "C-c C-d q" 'gdscript-debug-make-server
+  "C-c C-d n" 'gdscript-debug-next
+  "C-c C-d c" 'gdscript-debug-continue
+  "<f7>" 'gdscript-debug-continue
+  "C-c C-d s" 'gdscript-debug-step
+  ;; Debugger Hydra
+  "C-c n" 'gdscript-debug-hydra)
 
 (easy-menu-define gdscript-mode-menu gdscript-mode-map
   "Menu for GDScript mode."


### PR DESCRIPTION
Reduces the boilerplate, ~no behaviour changes.~ This also changes two keybindings in response to #210:
- `C-c n` is now `C-c C-n`
- `C-c i` is now `C-c C-i`

