### PR TITLE
Add Transient menus

### DIFF
--- a/gdscript-menu.el
+++ b/gdscript-menu.el
@@ -1,0 +1,117 @@
+;;; gdscript-menu.el --- Godot transient menus -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2020-2026 GDQuest and contributors.
+
+;; Author: John Charman <jchar@mailfence.com>
+;; Maintainer: Jen-Chieh Shen <jcs090218@gmail.com>
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Discoverable menus for common tasks in Godot game development.
+;; - Call `gdscript-menu' for the main entrypoint.
+;; - Call `gdscript-menu-godot' for launching the Godot engine.
+;; - Call `gdscript-menu-gdscript' for GDScript.
+
+;;; Code:
+
+(require 'transient) ; Built-in
+
+;; For gdscript-menu-godot commands
+(require 'gdscript-godot)
+
+;; For gdscript-menu-gdscript commands
+(require 'gdscript-docs)
+(require 'gdscript-format)
+
+; To display project name all menus
+(require 'gdscript-utils)
+
+
+;; Main Menu
+(transient-define-prefix gdscript-menu ()
+  "Main menu for Godot."
+  ["Godot Main Menu"
+   :description (lambda ()
+                  (format "Godot: %s" (gdscript-util--get-godot-project-name)))
+   ("g" "Godot Engine" gdscript-menu-godot)
+   ("s" "GDScript" gdscript-menu-gdscript)])
+
+
+;; Godot Menu
+(transient-define-prefix gdscript-menu-godot ()
+  "Menu for launching the Godot executable."
+  :history-key 'gdscript-menu-godot-history
+  :incompatible '(("--debug" "--editor"))
+  ["Godot Executable"
+   :description (lambda ()
+                  (format "Godot Engine: %s" (gdscript-util--get-godot-project-name)))
+   [("<f5>" "project" gd//run-project)]
+   [("<f6>" "current scene" gd//run-current-scene)]]
+  [["Run Options"
+    ("-d" "stdout debugger" "--debug")
+    ("-e" "open in editor" "--editor")
+    ("-h" "headless mode" "--headless")
+    ("-r" "recovery mode" "--recovery-mode")]
+   ["Debug Options"
+    ("-c" "show collision shapes" "--debug-collisions")
+    ("-p" "show path lines" "--debug-paths")
+    ("-n" "show navigation polygons" "--debug-navigation")
+    ("-a" "show navigation avoidance" "--debug-avoidance")]])
+
+(transient-define-suffix gd//run-project (prefix)
+  "Report the PREFIX-ARG, prefix's scope, and infix values."
+  (interactive "P")
+  (transient-save)
+  (let ((args (transient-args transient-current-command)))
+    (gdscript-comint--run
+     `(,@args
+       "--path" ,(gdscript-util--find-project-configuration-file)))))
+
+
+(transient-define-suffix gd//run-current-scene (prefix)
+  "Report the PREFIX-ARG, prefix's scope, and infix values."
+  (interactive "P")
+  (transient-save)
+  (let ((args (transient-args transient-current-command)))
+    (gdscript-comint--run
+     `(,@args
+       "--scene" ,(gdscript-godot--select-scene)))))
+
+
+;; GDScript menu
+(transient-define-prefix gdscript-menu-gdscript ()
+  "Menu for GDScript files"
+  ["GDScript"
+   :description (lambda () (format "GDScript: %s"
+                                   (gdscript-util--get-godot-project-name)))
+   ["Docs"
+    ("d" "browse" gdscript-docs-browse-api)]
+   ["GDFormat"
+    :description (lambda () (if (file-exists-p gdscript-gdformat-executable)
+                                "GDFormat"
+                                "GDFormat (not found)"))
+    :inapt-if-not (lambda () (file-exists-p gdscript-gdformat-executable))
+    ("f" "buffer" gdscript-format-buffer)
+    ("F" "all" gdscript-format-all)]])
+
+
+(provide 'gdscript-menu)
+;; Local Variables:
+;; read-symbol-shorthands: (("gd//" . "gdscript-menu--"))
+;; End:
+;;; gdscript-menu.el ends here

--- a/gdscript-mode.el
+++ b/gdscript-mode.el
@@ -36,6 +36,7 @@
 (require 'gdscript-syntax)
 (require 'gdscript-indent-and-nav)
 (require 'gdscript-imenu)
+(require 'gdscript-menu)
 (require 'gdscript-fill-paragraph)
 (require 'gdscript-completion)
 (require 'gdscript-format)


### PR DESCRIPTION
# Features
## Main Menu `gdscript-menu`

<img width="936" height="97" alt="Screenshot From 2026-06-20 08-22-01" src="https://github.com/user-attachments/assets/a6a849f4-c882-46e2-94af-93135c5b9d04" />

A main entry point that we could assign to a key, removing the need to memorise complex keychords. Think of it like a bespoke `which-key-mode`.

## Godot Engine Menu `gdscript-menu-godot`:
<img width="931" height="220" alt="Screenshot From 2026-06-20 08-22-13" src="https://github.com/user-attachments/assets/f2b1f6e9-2cc3-4538-b9b2-10bb7d6a3bca" />

Wrapping a CLI tool is where [Transient](https://github.com/magit/transient) really shines, if you've used [Magit](https://github.com/magit/magit) then the way this menu works should be familiar.

### Built In History
I've set up this menu to use transient's built-in history: navigatable with `C-x p` `C-x n`.

### Saves Last Used Flags
Each time you open the menu, it starts with the same flags you used last. This persists across emacs sessions.

## GDScript Menu `gdscript-menu-gdscript`
<img width="934" height="120" alt="Screenshot From 2026-06-20 08-22-24" src="https://github.com/user-attachments/assets/2b1403fd-3f6f-4160-9db4-d59f0b421bed" />

### Conditionally disable GDFormat commands when executable is missing

We could instead hide them completely, but that would make the feature less discoverable.

# Additional Notes

## Shorthands

I used a [Shorthand](https://www.gnu.org/software/emacs/manual/html_node/elisp/Shorthands.html) `gd//` for transient-specific code. (Emacs automatically translates this into `gdscript-menu--`). I've done this for two reasons:
1. It's concise
2. To discourage external use of internal details.

## Missing Menu options

### Script
This option has been left out as it has [confused users](https://github.com/godotengine/emacs-gdscript-mode/issues/168) in the past, including me. This could be reconsidered if we make it clear when it will work (via conditional disabling for instance)

### Switch to Godot
This may be a personal taste, but I don't use this option. I just use the familiar `switch-to-buffer` if I want to switch buffer. I'd be curious to hear feedback on this one from other users.